### PR TITLE
Add agent-first template to flake.nix file

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,5 +51,12 @@
       overlays.default = overlay;
       homeManagerModules.clawdbot = import ./nix/modules/home-manager/clawdbot.nix;
       darwinModules.clawdbot = import ./nix/modules/darwin/clawdbot.nix;
+
+      templates = {
+        agent-first = {
+          path = ./templates/agent-first;
+          description = "Agent-first template for clawdbot";
+        };
+      };
     };
 }


### PR DESCRIPTION
## The Problem

When running `nix flake init -t github:clawdbot/nix-clawdbot#agent-first` I received an error:
```
error: flake 'github:clawdbot/nix-clawdbot' does not provide attribute 'templates.agent-first' or 'agent-first'
```

The templates need to be added to `flake.nix`:
```
templates = {
  agent-first = {
    path = ./templates/agent-first;
    description = "Agent-first template for clawdbot";
  };
};
```

## Testing

You can test the branch directly using this command:

```
nix flake init -t github:bjtitus/nix-clawdbot/flake-templates#agent-first
```

Result:

```
wrote: "/Users/bjtitus/Developer/clawdbot/flake.nix"
wrote: "/Users/bjtitus/Developer/clawdbot/documents/SOUL.md"
wrote: "/Users/bjtitus/Developer/clawdbot/documents/AGENTS.md"
wrote: "/Users/bjtitus/Developer/clawdbot/documents/TOOLS.md"
wrote: "/Users/bjtitus/Developer/clawdbot/documents"
```