### PR TITLE
feat: add aarch64-linux support (Raspberry Pi 5)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
       systems = [
         "x86_64-linux"
         "aarch64-darwin"
+        "aarch64-linux"
       ];
     in
     flake-utils.lib.eachSystem systems (


### PR DESCRIPTION
- Add `aarch64-linux` to supported systems (enables Raspberry Pi 5, other ARM64 Linux devices)

## Testing

Tested on Raspberry Pi 5 running NixOS via nixos-raspberrypi:
- Gateway builds and runs successfully
- Home-manager activation completes without errors
- Service starts and serves web UI