### PR TITLE
Update gateway version to 2026.1.23, fix defaultInstance bugs, and enhance auto-update

### DIFF
--- a/nix/checks/clawdbot-config-options.nix
+++ b/nix/checks/clawdbot-config-options.nix
@@ -34,7 +34,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "clawdbot-config-options";
-  version = "2026.1.8-2";
+  version = "2026.1.16-2";
 
   src = fetchFromGitHub sourceFetch;
 

--- a/nix/checks/clawdbot-gateway-tests.nix
+++ b/nix/checks/clawdbot-gateway-tests.nix
@@ -35,7 +35,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "clawdbot-gateway-tests";
-  version = "2026.1.8-2";
+  version = "2026.1.16-2";
 
   src = fetchFromGitHub sourceFetch;
 

--- a/nix/generated/clawdbot-config-options.nix
+++ b/nix/generated/clawdbot-config-options.nix
@@ -194,15 +194,6 @@ in
       elevatedDefault = lib.mkOption {
         type = t.oneOf [ t.enum [ "off" ] t.enum [ "on" ] ];
       };
-      envelopeElapsed = lib.mkOption {
-        type = t.oneOf [ t.enum [ "on" ] t.enum [ "off" ] ];
-      };
-      envelopeTimestamp = lib.mkOption {
-        type = t.oneOf [ t.enum [ "on" ] t.enum [ "off" ] ];
-      };
-      envelopeTimezone = lib.mkOption {
-        type = t.str;
-      };
       heartbeat = lib.mkOption {
         type = t.submodule { options = {
         ackMaxChars = lib.mkOption {
@@ -259,16 +250,6 @@ in
       };
       memorySearch = lib.mkOption {
         type = t.submodule { options = {
-        cache = lib.mkOption {
-          type = t.submodule { options = {
-          enabled = lib.mkOption {
-            type = t.bool;
-          };
-          maxEntries = lib.mkOption {
-            type = t.int;
-          };
-        }; };
-        };
         chunking = lib.mkOption {
           type = t.submodule { options = {
           overlap = lib.mkOption {
@@ -282,15 +263,8 @@ in
         enabled = lib.mkOption {
           type = t.bool;
         };
-        experimental = lib.mkOption {
-          type = t.submodule { options = {
-          sessionMemory = lib.mkOption {
-            type = t.bool;
-          };
-        }; };
-        };
         fallback = lib.mkOption {
-          type = t.oneOf [ t.enum [ "openai" ] t.enum [ "gemini" ] t.enum [ "local" ] t.enum [ "none" ] ];
+          type = t.oneOf [ t.enum [ "openai" ] t.enum [ "none" ] ];
         };
         local = lib.mkOption {
           type = t.submodule { options = {
@@ -306,26 +280,10 @@ in
           type = t.str;
         };
         provider = lib.mkOption {
-          type = t.oneOf [ t.enum [ "openai" ] t.enum [ "local" ] t.enum [ "gemini" ] ];
+          type = t.oneOf [ t.enum [ "openai" ] t.enum [ "local" ] ];
         };
         query = lib.mkOption {
           type = t.submodule { options = {
-          hybrid = lib.mkOption {
-            type = t.submodule { options = {
-            candidateMultiplier = lib.mkOption {
-              type = t.int;
-            };
-            enabled = lib.mkOption {
-              type = t.bool;
-            };
-            textWeight = lib.mkOption {
-              type = t.number;
-            };
-            vectorWeight = lib.mkOption {
-              type = t.number;
-            };
-          }; };
-          };
           maxResults = lib.mkOption {
             type = t.int;
           };
@@ -342,32 +300,10 @@ in
           baseUrl = lib.mkOption {
             type = t.str;
           };
-          batch = lib.mkOption {
-            type = t.submodule { options = {
-            concurrency = lib.mkOption {
-              type = t.int;
-            };
-            enabled = lib.mkOption {
-              type = t.bool;
-            };
-            pollIntervalMs = lib.mkOption {
-              type = t.int;
-            };
-            timeoutMinutes = lib.mkOption {
-              type = t.int;
-            };
-            wait = lib.mkOption {
-              type = t.bool;
-            };
-          }; };
-          };
           headers = lib.mkOption {
             type = t.attrsOf (t.str);
           };
         }; };
-        };
-        sources = lib.mkOption {
-          type = t.listOf (t.oneOf [ t.enum [ "memory" ] t.enum [ "sessions" ] ]);
         };
         store = lib.mkOption {
           type = t.submodule { options = {
@@ -376,16 +312,6 @@ in
           };
           path = lib.mkOption {
             type = t.str;
-          };
-          vector = lib.mkOption {
-            type = t.submodule { options = {
-            enabled = lib.mkOption {
-              type = t.bool;
-            };
-            extensionPath = lib.mkOption {
-              type = t.str;
-            };
-          }; };
           };
         }; };
         };
@@ -702,16 +628,6 @@ in
       };
       memorySearch = lib.mkOption {
         type = t.submodule { options = {
-        cache = lib.mkOption {
-          type = t.submodule { options = {
-          enabled = lib.mkOption {
-            type = t.bool;
-          };
-          maxEntries = lib.mkOption {
-            type = t.int;
-          };
-        }; };
-        };
         chunking = lib.mkOption {
           type = t.submodule { options = {
           overlap = lib.mkOption {
@@ -725,15 +641,8 @@ in
         enabled = lib.mkOption {
           type = t.bool;
         };
-        experimental = lib.mkOption {
-          type = t.submodule { options = {
-          sessionMemory = lib.mkOption {
-            type = t.bool;
-          };
-        }; };
-        };
         fallback = lib.mkOption {
-          type = t.oneOf [ t.enum [ "openai" ] t.enum [ "gemini" ] t.enum [ "local" ] t.enum [ "none" ] ];
+          type = t.oneOf [ t.enum [ "openai" ] t.enum [ "none" ] ];
         };
         local = lib.mkOption {
           type = t.submodule { options = {
@@ -749,26 +658,10 @@ in
           type = t.str;
         };
         provider = lib.mkOption {
-          type = t.oneOf [ t.enum [ "openai" ] t.enum [ "local" ] t.enum [ "gemini" ] ];
+          type = t.oneOf [ t.enum [ "openai" ] t.enum [ "local" ] ];
         };
         query = lib.mkOption {
           type = t.submodule { options = {
-          hybrid = lib.mkOption {
-            type = t.submodule { options = {
-            candidateMultiplier = lib.mkOption {
-              type = t.int;
-            };
-            enabled = lib.mkOption {
-              type = t.bool;
-            };
-            textWeight = lib.mkOption {
-              type = t.number;
-            };
-            vectorWeight = lib.mkOption {
-              type = t.number;
-            };
-          }; };
-          };
           maxResults = lib.mkOption {
             type = t.int;
           };
@@ -785,32 +678,10 @@ in
           baseUrl = lib.mkOption {
             type = t.str;
           };
-          batch = lib.mkOption {
-            type = t.submodule { options = {
-            concurrency = lib.mkOption {
-              type = t.int;
-            };
-            enabled = lib.mkOption {
-              type = t.bool;
-            };
-            pollIntervalMs = lib.mkOption {
-              type = t.int;
-            };
-            timeoutMinutes = lib.mkOption {
-              type = t.int;
-            };
-            wait = lib.mkOption {
-              type = t.bool;
-            };
-          }; };
-          };
           headers = lib.mkOption {
             type = t.attrsOf (t.str);
           };
         }; };
-        };
-        sources = lib.mkOption {
-          type = t.listOf (t.oneOf [ t.enum [ "memory" ] t.enum [ "sessions" ] ]);
         };
         store = lib.mkOption {
           type = t.submodule { options = {
@@ -819,16 +690,6 @@ in
           };
           path = lib.mkOption {
             type = t.str;
-          };
-          vector = lib.mkOption {
-            type = t.submodule { options = {
-            enabled = lib.mkOption {
-              type = t.bool;
-            };
-            extensionPath = lib.mkOption {
-              type = t.str;
-            };
-          }; };
           };
         }; };
         };
@@ -1063,47 +924,6 @@ in
           };
         }; };
         };
-        exec = lib.mkOption {
-          type = t.submodule { options = {
-          applyPatch = lib.mkOption {
-            type = t.submodule { options = {
-            allowModels = lib.mkOption {
-              type = t.listOf (t.str);
-            };
-            enabled = lib.mkOption {
-              type = t.bool;
-            };
-          }; };
-          };
-          ask = lib.mkOption {
-            type = t.enum [ "off" "on-miss" "always" ];
-          };
-          backgroundMs = lib.mkOption {
-            type = t.int;
-          };
-          cleanupMs = lib.mkOption {
-            type = t.int;
-          };
-          host = lib.mkOption {
-            type = t.enum [ "sandbox" "gateway" "node" ];
-          };
-          node = lib.mkOption {
-            type = t.str;
-          };
-          notifyOnExit = lib.mkOption {
-            type = t.bool;
-          };
-          pathPrepend = lib.mkOption {
-            type = t.listOf (t.str);
-          };
-          security = lib.mkOption {
-            type = t.enum [ "deny" "allowlist" "full" ];
-          };
-          timeoutSec = lib.mkOption {
-            type = t.int;
-          };
-        }; };
-        };
         profile = lib.mkOption {
           type = t.oneOf [ t.enum [ "minimal" ] t.enum [ "coding" ] t.enum [ "messaging" ] t.enum [ "full" ] ];
         };
@@ -1217,6 +1037,39 @@ in
   }; });
   };
 
+  bridge = lib.mkOption {
+    type = t.submodule { options = {
+    bind = lib.mkOption {
+      type = t.oneOf [ t.enum [ "auto" ] t.enum [ "lan" ] t.enum [ "tailnet" ] t.enum [ "loopback" ] ];
+    };
+    enabled = lib.mkOption {
+      type = t.bool;
+    };
+    port = lib.mkOption {
+      type = t.int;
+    };
+    tls = lib.mkOption {
+      type = t.submodule { options = {
+      autoGenerate = lib.mkOption {
+        type = t.bool;
+      };
+      caPath = lib.mkOption {
+        type = t.str;
+      };
+      certPath = lib.mkOption {
+        type = t.str;
+      };
+      enabled = lib.mkOption {
+        type = t.bool;
+      };
+      keyPath = lib.mkOption {
+        type = t.str;
+      };
+    }; };
+    };
+  }; };
+  };
+
   broadcast = lib.mkOption {
     type = t.submodule { options = {
     strategy = lib.mkOption {
@@ -1301,214 +1154,6 @@ in
 
   channels = lib.mkOption {
     type = t.submodule { options = {
-    bluebubbles = lib.mkOption {
-      type = t.submodule { options = {
-      accounts = lib.mkOption {
-        type = t.attrsOf (t.submodule { options = {
-        allowFrom = lib.mkOption {
-          type = t.listOf (t.oneOf [ t.str t.number ]);
-        };
-        blockStreaming = lib.mkOption {
-          type = t.bool;
-        };
-        blockStreamingCoalesce = lib.mkOption {
-          type = t.submodule { options = {
-          idleMs = lib.mkOption {
-            type = t.int;
-          };
-          maxChars = lib.mkOption {
-            type = t.int;
-          };
-          minChars = lib.mkOption {
-            type = t.int;
-          };
-        }; };
-        };
-        capabilities = lib.mkOption {
-          type = t.listOf (t.str);
-        };
-        configWrites = lib.mkOption {
-          type = t.bool;
-        };
-        dmHistoryLimit = lib.mkOption {
-          type = t.int;
-        };
-        dmPolicy = lib.mkOption {
-          type = t.enum [ "pairing" "allowlist" "open" "disabled" ];
-        };
-        dms = lib.mkOption {
-          type = t.attrsOf (t.submodule { options = {
-          historyLimit = lib.mkOption {
-            type = t.int;
-          };
-        }; });
-        };
-        enabled = lib.mkOption {
-          type = t.bool;
-        };
-        groupAllowFrom = lib.mkOption {
-          type = t.listOf (t.oneOf [ t.str t.number ]);
-        };
-        groupPolicy = lib.mkOption {
-          type = t.enum [ "open" "disabled" "allowlist" ];
-        };
-        groups = lib.mkOption {
-          type = t.attrsOf (t.submodule { options = {
-          requireMention = lib.mkOption {
-            type = t.bool;
-          };
-        }; });
-        };
-        historyLimit = lib.mkOption {
-          type = t.int;
-        };
-        mediaMaxMb = lib.mkOption {
-          type = t.int;
-        };
-        name = lib.mkOption {
-          type = t.str;
-        };
-        password = lib.mkOption {
-          type = t.str;
-        };
-        sendReadReceipts = lib.mkOption {
-          type = t.bool;
-        };
-        serverUrl = lib.mkOption {
-          type = t.str;
-        };
-        textChunkLimit = lib.mkOption {
-          type = t.int;
-        };
-        webhookPath = lib.mkOption {
-          type = t.str;
-        };
-      }; });
-      };
-      actions = lib.mkOption {
-        type = t.submodule { options = {
-        addParticipant = lib.mkOption {
-          type = t.bool;
-        };
-        edit = lib.mkOption {
-          type = t.bool;
-        };
-        leaveGroup = lib.mkOption {
-          type = t.bool;
-        };
-        reactions = lib.mkOption {
-          type = t.bool;
-        };
-        removeParticipant = lib.mkOption {
-          type = t.bool;
-        };
-        renameGroup = lib.mkOption {
-          type = t.bool;
-        };
-        reply = lib.mkOption {
-          type = t.bool;
-        };
-        sendAttachment = lib.mkOption {
-          type = t.bool;
-        };
-        sendWithEffect = lib.mkOption {
-          type = t.bool;
-        };
-        setGroupIcon = lib.mkOption {
-          type = t.bool;
-        };
-        unsend = lib.mkOption {
-          type = t.bool;
-        };
-      }; };
-      };
-      allowFrom = lib.mkOption {
-        type = t.listOf (t.oneOf [ t.str t.number ]);
-      };
-      blockStreaming = lib.mkOption {
-        type = t.bool;
-      };
-      blockStreamingCoalesce = lib.mkOption {
-        type = t.submodule { options = {
-        idleMs = lib.mkOption {
-          type = t.int;
-        };
-        maxChars = lib.mkOption {
-          type = t.int;
-        };
-        minChars = lib.mkOption {
-          type = t.int;
-        };
-      }; };
-      };
-      capabilities = lib.mkOption {
-        type = t.listOf (t.str);
-      };
-      configWrites = lib.mkOption {
-        type = t.bool;
-      };
-      dmHistoryLimit = lib.mkOption {
-        type = t.int;
-      };
-      dmPolicy = lib.mkOption {
-        type = t.enum [ "pairing" "allowlist" "open" "disabled" ];
-      };
-      dms = lib.mkOption {
-        type = t.attrsOf (t.submodule { options = {
-        historyLimit = lib.mkOption {
-          type = t.int;
-        };
-      }; });
-      };
-      enabled = lib.mkOption {
-        type = t.bool;
-      };
-      groupAllowFrom = lib.mkOption {
-        type = t.listOf (t.oneOf [ t.str t.number ]);
-      };
-      groupPolicy = lib.mkOption {
-        type = t.enum [ "open" "disabled" "allowlist" ];
-      };
-      groups = lib.mkOption {
-        type = t.attrsOf (t.submodule { options = {
-        requireMention = lib.mkOption {
-          type = t.bool;
-        };
-      }; });
-      };
-      historyLimit = lib.mkOption {
-        type = t.int;
-      };
-      mediaMaxMb = lib.mkOption {
-        type = t.int;
-      };
-      name = lib.mkOption {
-        type = t.str;
-      };
-      password = lib.mkOption {
-        type = t.str;
-      };
-      sendReadReceipts = lib.mkOption {
-        type = t.bool;
-      };
-      serverUrl = lib.mkOption {
-        type = t.str;
-      };
-      textChunkLimit = lib.mkOption {
-        type = t.int;
-      };
-      webhookPath = lib.mkOption {
-        type = t.str;
-      };
-    }; };
-    };
-    defaults = lib.mkOption {
-      type = t.submodule { options = {
-      groupPolicy = lib.mkOption {
-        type = t.enum [ "open" "disabled" "allowlist" ];
-      };
-    }; };
-    };
     discord = lib.mkOption {
       type = t.submodule { options = {
       accounts = lib.mkOption {
@@ -2544,9 +2189,6 @@ in
         mediaMaxMb = lib.mkOption {
           type = t.number;
         };
-        mode = lib.mkOption {
-          type = t.enum [ "socket" "http" ];
-        };
         name = lib.mkOption {
           type = t.str;
         };
@@ -2561,9 +2203,6 @@ in
         };
         requireMention = lib.mkOption {
           type = t.bool;
-        };
-        signingSecret = lib.mkOption {
-          type = t.str;
         };
         slashCommand = lib.mkOption {
           type = t.submodule { options = {
@@ -2599,9 +2238,6 @@ in
         };
         userTokenReadOnly = lib.mkOption {
           type = t.bool;
-        };
-        webhookPath = lib.mkOption {
-          type = t.str;
         };
       }; });
       };
@@ -2740,9 +2376,6 @@ in
       mediaMaxMb = lib.mkOption {
         type = t.number;
       };
-      mode = lib.mkOption {
-        type = t.enum [ "socket" "http" ];
-      };
       name = lib.mkOption {
         type = t.str;
       };
@@ -2757,9 +2390,6 @@ in
       };
       requireMention = lib.mkOption {
         type = t.bool;
-      };
-      signingSecret = lib.mkOption {
-        type = t.str;
       };
       slashCommand = lib.mkOption {
         type = t.submodule { options = {
@@ -2795,9 +2425,6 @@ in
       };
       userTokenReadOnly = lib.mkOption {
         type = t.bool;
-      };
-      webhookPath = lib.mkOption {
-        type = t.str;
       };
     }; };
     };
@@ -3450,48 +3077,6 @@ in
   }; };
   };
 
-  diagnostics = lib.mkOption {
-    type = t.submodule { options = {
-    enabled = lib.mkOption {
-      type = t.bool;
-    };
-    otel = lib.mkOption {
-      type = t.submodule { options = {
-      enabled = lib.mkOption {
-        type = t.bool;
-      };
-      endpoint = lib.mkOption {
-        type = t.str;
-      };
-      flushIntervalMs = lib.mkOption {
-        type = t.int;
-      };
-      headers = lib.mkOption {
-        type = t.attrsOf (t.str);
-      };
-      logs = lib.mkOption {
-        type = t.bool;
-      };
-      metrics = lib.mkOption {
-        type = t.bool;
-      };
-      protocol = lib.mkOption {
-        type = t.oneOf [ t.enum [ "http/protobuf" ] t.enum [ "grpc" ] ];
-      };
-      sampleRate = lib.mkOption {
-        type = t.number;
-      };
-      serviceName = lib.mkOption {
-        type = t.str;
-      };
-      traces = lib.mkOption {
-        type = t.bool;
-      };
-    }; };
-    };
-  }; };
-  };
-
   discovery = lib.mkOption {
     type = t.submodule { options = {
     wideArea = lib.mkOption {
@@ -3541,7 +3126,7 @@ in
     }; };
     };
     bind = lib.mkOption {
-      type = t.oneOf [ t.enum [ "auto" ] t.enum [ "lan" ] t.enum [ "loopback" ] t.enum [ "custom" ] ];
+      type = t.oneOf [ t.enum [ "auto" ] t.enum [ "lan" ] t.enum [ "tailnet" ] t.enum [ "loopback" ] ];
     };
     controlUi = lib.mkOption {
       type = t.submodule { options = {
@@ -3564,86 +3149,12 @@ in
           };
         }; };
         };
-        responses = lib.mkOption {
-          type = t.submodule { options = {
-          enabled = lib.mkOption {
-            type = t.bool;
-          };
-          files = lib.mkOption {
-            type = t.submodule { options = {
-            allowUrl = lib.mkOption {
-              type = t.bool;
-            };
-            allowedMimes = lib.mkOption {
-              type = t.listOf (t.str);
-            };
-            maxBytes = lib.mkOption {
-              type = t.int;
-            };
-            maxChars = lib.mkOption {
-              type = t.int;
-            };
-            maxRedirects = lib.mkOption {
-              type = t.int;
-            };
-            pdf = lib.mkOption {
-              type = t.submodule { options = {
-              maxPages = lib.mkOption {
-                type = t.int;
-              };
-              maxPixels = lib.mkOption {
-                type = t.int;
-              };
-              minTextChars = lib.mkOption {
-                type = t.int;
-              };
-            }; };
-            };
-            timeoutMs = lib.mkOption {
-              type = t.int;
-            };
-          }; };
-          };
-          images = lib.mkOption {
-            type = t.submodule { options = {
-            allowUrl = lib.mkOption {
-              type = t.bool;
-            };
-            allowedMimes = lib.mkOption {
-              type = t.listOf (t.str);
-            };
-            maxBytes = lib.mkOption {
-              type = t.int;
-            };
-            maxRedirects = lib.mkOption {
-              type = t.int;
-            };
-            timeoutMs = lib.mkOption {
-              type = t.int;
-            };
-          }; };
-          };
-          maxBodyBytes = lib.mkOption {
-            type = t.int;
-          };
-        }; };
-        };
       }; };
       };
     }; };
     };
     mode = lib.mkOption {
       type = t.oneOf [ t.enum [ "local" ] t.enum [ "remote" ] ];
-    };
-    nodes = lib.mkOption {
-      type = t.submodule { options = {
-      allowCommands = lib.mkOption {
-        type = t.listOf (t.str);
-      };
-      denyCommands = lib.mkOption {
-        type = t.listOf (t.str);
-      };
-    }; };
     };
     port = lib.mkOption {
       type = t.int;
@@ -3669,9 +3180,6 @@ in
       sshTarget = lib.mkOption {
         type = t.str;
       };
-      tlsFingerprint = lib.mkOption {
-        type = t.str;
-      };
       token = lib.mkOption {
         type = t.str;
       };
@@ -3687,25 +3195,6 @@ in
       };
       resetOnExit = lib.mkOption {
         type = t.bool;
-      };
-    }; };
-    };
-    tls = lib.mkOption {
-      type = t.submodule { options = {
-      autoGenerate = lib.mkOption {
-        type = t.bool;
-      };
-      caPath = lib.mkOption {
-        type = t.str;
-      };
-      certPath = lib.mkOption {
-        type = t.str;
-      };
-      enabled = lib.mkOption {
-        type = t.bool;
-      };
-      keyPath = lib.mkOption {
-        type = t.str;
       };
     }; };
     };
@@ -4055,17 +3544,6 @@ in
   }; };
   };
 
-  meta = lib.mkOption {
-    type = t.submodule { options = {
-    lastTouchedAt = lib.mkOption {
-      type = t.str;
-    };
-    lastTouchedVersion = lib.mkOption {
-      type = t.str;
-    };
-  }; };
-  };
-
   models = lib.mkOption {
     type = t.submodule { options = {
     mode = lib.mkOption {
@@ -4074,13 +3552,10 @@ in
     providers = lib.mkOption {
       type = t.attrsOf (t.submodule { options = {
       api = lib.mkOption {
-        type = t.oneOf [ t.enum [ "openai-completions" ] t.enum [ "openai-responses" ] t.enum [ "anthropic-messages" ] t.enum [ "google-generative-ai" ] t.enum [ "github-copilot" ] t.enum [ "bedrock-converse-stream" ] ];
+        type = t.oneOf [ t.enum [ "openai-completions" ] t.enum [ "openai-responses" ] t.enum [ "anthropic-messages" ] t.enum [ "google-generative-ai" ] t.enum [ "github-copilot" ] ];
       };
       apiKey = lib.mkOption {
         type = t.str;
-      };
-      auth = lib.mkOption {
-        type = t.oneOf [ t.enum [ "api-key" ] t.enum [ "aws-sdk" ] t.enum [ "oauth" ] t.enum [ "token" ] ];
       };
       authHeader = lib.mkOption {
         type = t.bool;
@@ -4094,7 +3569,7 @@ in
       models = lib.mkOption {
         type = t.listOf (t.submodule { options = {
         api = lib.mkOption {
-          type = t.oneOf [ t.enum [ "openai-completions" ] t.enum [ "openai-responses" ] t.enum [ "anthropic-messages" ] t.enum [ "google-generative-ai" ] t.enum [ "github-copilot" ] t.enum [ "bedrock-converse-stream" ] ];
+          type = t.oneOf [ t.enum [ "openai-completions" ] t.enum [ "openai-responses" ] t.enum [ "anthropic-messages" ] t.enum [ "google-generative-ai" ] t.enum [ "github-copilot" ] ];
         };
         compat = lib.mkOption {
           type = t.submodule { options = {
@@ -4206,13 +3681,6 @@ in
       };
     }; };
     };
-    slots = lib.mkOption {
-      type = t.submodule { options = {
-      memory = lib.mkOption {
-        type = t.str;
-      };
-    }; };
-    };
   }; };
   };
 
@@ -4239,62 +3707,6 @@ in
     };
     mainKey = lib.mkOption {
       type = t.str;
-    };
-    reset = lib.mkOption {
-      type = t.submodule { options = {
-      atHour = lib.mkOption {
-        type = t.int;
-      };
-      idleMinutes = lib.mkOption {
-        type = t.int;
-      };
-      mode = lib.mkOption {
-        type = t.oneOf [ t.enum [ "daily" ] t.enum [ "idle" ] ];
-      };
-    }; };
-    };
-    resetByType = lib.mkOption {
-      type = t.submodule { options = {
-      dm = lib.mkOption {
-        type = t.submodule { options = {
-        atHour = lib.mkOption {
-          type = t.int;
-        };
-        idleMinutes = lib.mkOption {
-          type = t.int;
-        };
-        mode = lib.mkOption {
-          type = t.oneOf [ t.enum [ "daily" ] t.enum [ "idle" ] ];
-        };
-      }; };
-      };
-      group = lib.mkOption {
-        type = t.submodule { options = {
-        atHour = lib.mkOption {
-          type = t.int;
-        };
-        idleMinutes = lib.mkOption {
-          type = t.int;
-        };
-        mode = lib.mkOption {
-          type = t.oneOf [ t.enum [ "daily" ] t.enum [ "idle" ] ];
-        };
-      }; };
-      };
-      thread = lib.mkOption {
-        type = t.submodule { options = {
-        atHour = lib.mkOption {
-          type = t.int;
-        };
-        idleMinutes = lib.mkOption {
-          type = t.int;
-        };
-        mode = lib.mkOption {
-          type = t.oneOf [ t.enum [ "daily" ] t.enum [ "idle" ] ];
-        };
-      }; };
-      };
-    }; };
     };
     resetTriggers = lib.mkOption {
       type = t.listOf (t.str);
@@ -4350,9 +3762,6 @@ in
       type = t.attrsOf (t.submodule { options = {
       apiKey = lib.mkOption {
         type = t.str;
-      };
-      config = lib.mkOption {
-        type = t.attrsOf (t.anything);
       };
       enabled = lib.mkOption {
         type = t.bool;
@@ -4464,29 +3873,14 @@ in
         };
       }; };
       };
-      ask = lib.mkOption {
-        type = t.enum [ "off" "on-miss" "always" ];
-      };
       backgroundMs = lib.mkOption {
         type = t.int;
       };
       cleanupMs = lib.mkOption {
         type = t.int;
       };
-      host = lib.mkOption {
-        type = t.enum [ "sandbox" "gateway" "node" ];
-      };
-      node = lib.mkOption {
-        type = t.str;
-      };
       notifyOnExit = lib.mkOption {
         type = t.bool;
-      };
-      pathPrepend = lib.mkOption {
-        type = t.listOf (t.str);
-      };
-      security = lib.mkOption {
-        type = t.enum [ "deny" "allowlist" "full" ];
       };
       timeoutSec = lib.mkOption {
         type = t.int;
@@ -5115,21 +4509,8 @@ in
         maxResults = lib.mkOption {
           type = t.int;
         };
-        perplexity = lib.mkOption {
-          type = t.submodule { options = {
-          apiKey = lib.mkOption {
-            type = t.str;
-          };
-          baseUrl = lib.mkOption {
-            type = t.str;
-          };
-          model = lib.mkOption {
-            type = t.str;
-          };
-        }; };
-        };
         provider = lib.mkOption {
-          type = t.oneOf [ t.enum [ "brave" ] t.enum [ "perplexity" ] ];
+          type = t.oneOf [ t.enum [ "brave" ] ];
         };
         timeoutSeconds = lib.mkOption {
           type = t.int;
@@ -5152,7 +4533,7 @@ in
   update = lib.mkOption {
     type = t.submodule { options = {
     channel = lib.mkOption {
-      type = t.oneOf [ t.enum [ "stable" ] t.enum [ "beta" ] t.enum [ "dev" ] ];
+      type = t.oneOf [ t.enum [ "stable" ] t.enum [ "beta" ] ];
     };
     checkOnStart = lib.mkOption {
       type = t.bool;

--- a/nix/modules/home-manager/clawdbot.nix
+++ b/nix/modules/home-manager/clawdbot.nix
@@ -302,7 +302,12 @@ let
     gatewayPort = 18789;
     gatewayPath = null;
     gatewayPnpmDepsHash = lib.fakeHash;
-    providers = cfg.providers;
+    providers = {
+      anthropic = cfg.providers.anthropic;
+      telegram = cfg.providers.telegram // {
+        groups = {};
+      };
+    };
     routing = cfg.routing;
     launchd = {
       enable = cfg.launchd.enable;

--- a/nix/modules/home-manager/clawdbot.nix
+++ b/nix/modules/home-manager/clawdbot.nix
@@ -300,6 +300,8 @@ let
     configPath = "${cfg.stateDir}/clawdbot.json";
     logPath = "/tmp/clawdbot/clawdbot-gateway.log";
     gatewayPort = 18789;
+    gatewayPath = null;
+    gatewayPnpmDepsHash = lib.fakeHash;
     providers = cfg.providers;
     routing = cfg.routing;
     launchd = {

--- a/nix/modules/home-manager/clawdbot.nix
+++ b/nix/modules/home-manager/clawdbot.nix
@@ -302,9 +302,19 @@ let
     gatewayPort = 18789;
     providers = cfg.providers;
     routing = cfg.routing;
-    launchd = cfg.launchd;
-    systemd = cfg.systemd;
+    launchd = {
+      enable = cfg.launchd.enable;
+      label = "com.steipete.clawdbot.gateway";
+    };
+    systemd = {
+      enable = cfg.systemd.enable;
+      unitName = "clawdbot-gateway";
+    };
     plugins = cfg.plugins;
+    agent = {
+      model = cfg.defaults.model;
+      thinkingDefault = cfg.defaults.thinkingDefault;
+    };
     configOverrides = {};
     config = {};
     appDefaults = {

--- a/nix/modules/home-manager/clawdbot.nix
+++ b/nix/modules/home-manager/clawdbot.nix
@@ -36,11 +36,13 @@ let
   };
 
   mkTelegramConfig = inst: lib.optionalAttrs inst.providers.telegram.enable {
-    telegram = {
-      enabled = true;
-      tokenFile = inst.providers.telegram.botTokenFile;
-      allowFrom = inst.providers.telegram.allowFrom;
-      groups = inst.providers.telegram.groups;
+    channels = {
+      telegram = {
+        enabled = true;
+        tokenFile = inst.providers.telegram.botTokenFile;
+        allowFrom = inst.providers.telegram.allowFrom;
+        groups = inst.providers.telegram.groups;
+      };
     };
   };
 

--- a/nix/modules/home-manager/clawdbot.nix
+++ b/nix/modules/home-manager/clawdbot.nix
@@ -50,7 +50,6 @@ let
     messages = {
       queue = {
         mode = inst.routing.queue.mode;
-        byProvider = inst.routing.queue.byProvider;
       };
     };
   };

--- a/nix/packages/clawdbot-gateway-runner.nix
+++ b/nix/packages/clawdbot-gateway-runner.nix
@@ -1,0 +1,125 @@
+{ lib
+, stdenvNoCC
+, writeShellScript
+}:
+
+# Creates a minimal .app bundle that runs the clawdbot gateway.
+# This .app can be granted Full Disk Access in System Preferences,
+# which is required for iMessage support (imsg needs to read Messages.db).
+#
+# The LaunchAgent runs this .app's executable directly, passing environment
+# variables (CLAWDBOT_CONFIG_PATH, CLAWDBOT_STATE_DIR, etc.) and handling
+# stdout/stderr logging.
+#
+# Usage: 
+#   1. Build and install this .app to ~/Applications/
+#   2. Grant FDA in System Settings > Privacy & Security > Full Disk Access
+#   3. The LaunchAgent will run the app's executable with proper env vars
+
+{ instanceName ? "default"
+, gatewayWrapper  # The gateway wrapper script (with env vars, plugin paths, etc.)
+, stateDir        # Used for working directory context
+, logPath         # Informational (actual logging handled by LaunchAgent)
+, gatewayPort ? 18789
+, homeDir ? ""    # Home directory for env var fallback
+, configPath ? "" # Config path for env var fallback
+}:
+
+let
+  appName = if instanceName == "default" 
+    then "Clawdbot Gateway Runner" 
+    else "Clawdbot Gateway Runner (${instanceName})";
+  
+  bundleId = if instanceName == "default"
+    then "com.clawdbot.gateway-runner"
+    else "com.clawdbot.gateway-runner.${instanceName}";
+
+  # The actual script that runs inside the .app
+  # Environment variables (CLAWDBOT_CONFIG_PATH, etc.) are set by the LaunchAgent
+  # stdout/stderr are handled by the LaunchAgent's StandardOutPath/StandardErrorPath
+  runnerScript = writeShellScript "clawdbot-gateway-runner" ''
+    #!/bin/bash
+    set -euo pipefail
+    
+    # The LaunchAgent sets these env vars, but provide fallbacks just in case
+    export HOME="''${HOME:-${homeDir}}"
+    export CLAWDBOT_CONFIG_PATH="''${CLAWDBOT_CONFIG_PATH:-${configPath}}"
+    export CLAWDBOT_STATE_DIR="''${CLAWDBOT_STATE_DIR:-${stateDir}}"
+    export CLAWDBOT_IMAGE_BACKEND="''${CLAWDBOT_IMAGE_BACKEND:-sips}"
+    export CLAWDBOT_NIX_MODE="''${CLAWDBOT_NIX_MODE:-1}"
+    
+    # Run the gateway - stdout/stderr handled by LaunchAgent
+    exec "${gatewayWrapper}/bin/clawdbot-gateway-${instanceName}" \
+      gateway \
+      --port ${toString gatewayPort}
+  '';
+
+  infoPlist = ''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>clawdbot-gateway-runner</string>
+  <key>CFBundleIconFile</key>
+  <string>AppIcon</string>
+  <key>CFBundleIdentifier</key>
+  <string>${bundleId}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${appName}</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>11.0</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+'';
+
+in stdenvNoCC.mkDerivation {
+  pname = "clawdbot-gateway-runner";
+  version = "1.0.0";
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    APP_DIR="$out/Applications/${appName}.app"
+    mkdir -p "$APP_DIR/Contents/MacOS"
+    mkdir -p "$APP_DIR/Contents/Resources"
+
+    # Write Info.plist
+    cat > "$APP_DIR/Contents/Info.plist" << 'PLIST_EOF'
+${infoPlist}
+PLIST_EOF
+
+    # Copy the runner script as the executable
+    cp "${runnerScript}" "$APP_DIR/Contents/MacOS/clawdbot-gateway-runner"
+    chmod +x "$APP_DIR/Contents/MacOS/clawdbot-gateway-runner"
+
+    # Create PkgInfo
+    echo -n "APPL????" > "$APP_DIR/Contents/PkgInfo"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Clawdbot Gateway Runner - minimal .app for FDA permissions";
+    homepage = "https://github.com/clawdbot/clawdbot";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+  };
+}

--- a/nix/packages/clawdbot-gateway-runner.nix
+++ b/nix/packages/clawdbot-gateway-runner.nix
@@ -1,6 +1,13 @@
 { lib
 , stdenvNoCC
 , writeShellScript
+, instanceName ? "default"
+, gatewayWrapper
+, stateDir
+, logPath
+, gatewayPort ? 18789
+, homeDir ? ""
+, configPath ? ""
 }:
 
 # Creates a minimal .app bundle that runs the clawdbot gateway.
@@ -15,15 +22,6 @@
 #   1. Build and install this .app to ~/Applications/
 #   2. Grant FDA in System Settings > Privacy & Security > Full Disk Access
 #   3. The LaunchAgent will run the app's executable with proper env vars
-
-{ instanceName ? "default"
-, gatewayWrapper  # The gateway wrapper script (with env vars, plugin paths, etc.)
-, stateDir        # Used for working directory context
-, logPath         # Informational (actual logging handled by LaunchAgent)
-, gatewayPort ? 18789
-, homeDir ? ""    # Home directory for env var fallback
-, configPath ? "" # Config path for env var fallback
-}:
 
 let
   appName = if instanceName == "default" 

--- a/nix/packages/clawdbot-gateway.nix
+++ b/nix/packages/clawdbot-gateway.nix
@@ -38,7 +38,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "clawdbot-gateway";
-  version = "2026.1.8-2";
+  version = "2026.1.16-2";
 
   src = if gatewaySrc != null then gatewaySrc else fetchFromGitHub sourceFetch;
 

--- a/nix/packages/clawdbot-gateway.nix
+++ b/nix/packages/clawdbot-gateway.nix
@@ -38,7 +38,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "clawdbot-gateway";
-  version = "2026.1.16-2";
+  version = "2026.1.23";
 
   src = if gatewaySrc != null then gatewaySrc else fetchFromGitHub sourceFetch;
 

--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -4,6 +4,18 @@ mkdir -p "$out/lib/clawdbot" "$out/bin"
 
 cp -r dist node_modules package.json ui "$out/lib/clawdbot/"
 
+# Copy extensions directory for channel plugins (telegram, discord, etc.)
+# See: https://github.com/clawdbot/nix-clawdbot/issues/6
+if [ -d "extensions" ]; then
+  cp -r extensions "$out/lib/clawdbot/"
+fi
+
+# Copy docs/reference/templates for workspace initialization
+if [ -d "docs/reference/templates" ]; then
+  mkdir -p "$out/lib/clawdbot/docs/reference"
+  cp -r docs/reference/templates "$out/lib/clawdbot/docs/reference/"
+fi
+
 if [ -z "${STDENV_SETUP:-}" ]; then
   echo "STDENV_SETUP is not set" >&2
   exit 1

--- a/nix/sources/clawdbot-source.nix
+++ b/nix/sources/clawdbot-source.nix
@@ -2,7 +2,7 @@
 {
   owner = "clawdbot";
   repo = "clawdbot";
-  rev = "be37b39782e0799ba5b9533561de6d128d50c863";
-  hash = "sha256-y1ToqEcfl0yVAJkVld0k5AX5tztiE7yJt/F7Rhg+dAc=";
-  pnpmDepsHash = "sha256-NPQrkhhvAoIYzR1gopqsErps1K/HkfxmrPXpyMlN0Bc=";
+  rev = "c9e98376b3e5d3a2f3a1639be53bd850f6d3acbf";
+  hash = "sha256-egAHjt6CHz79fStSg42opVPHjquurAa6FcGpNkQ0UtA=";
+  pnpmDepsHash = "sha256-N0rAUNutQ/zox1ZL6Lt/lwvXoPc5mbmW5mw3f0fSuKw=";
 }

--- a/nix/sources/clawdbot-source.nix
+++ b/nix/sources/clawdbot-source.nix
@@ -2,7 +2,7 @@
 {
   owner = "clawdbot";
   repo = "clawdbot";
-  rev = "e81ca7ab00ae8bf325691154cb3d8e2f410936ea";
-  hash = "sha256-HQRCRuCCWUwXN/KJ2S+8UzmxSkfRVPlGl14MK2fgvoc=";
-  pnpmDepsHash = "sha256-Uo++PJBXKk7pN6OwezMnAYQXR77lCYJkru7J+t/KK5U=";
+  rev = "be37b39782e0799ba5b9533561de6d128d50c863";
+  hash = "sha256-y1ToqEcfl0yVAJkVld0k5AX5tztiE7yJt/F7Rhg+dAc=";
+  pnpmDepsHash = "sha256-NPQrkhhvAoIYzR1gopqsErps1K/HkfxmrPXpyMlN0Bc=";
 }


### PR DESCRIPTION
## Summary
- Update gateway version from 2026.1.8-2 to 2026.1.16-2
- Fix multiple missing attributes in `defaultInstance` that caused errors when using `programs.clawdbot.enable = true` without explicit instances
- Enhance `update-pins.sh` to auto-update version strings in gateway and check derivations

## Changes

### Version Update
- Updated rev, hash, and pnpmDepsHash in `clawdbot-source.nix`
- Updated version string in `clawdbot-gateway.nix` and check derivations

### Bug Fixes
Added missing attributes to `defaultInstance`:
- `launchd.label` and `systemd.unitName` (was only inheriting `enable`)
- `agent` block (model and thinkingDefault)
- `gatewayPath` and `gatewayPnpmDepsHash`
- `providers.telegram.groups`

### Auto-Update Enhancement
Enhanced `scripts/update-pins.sh` to automatically update version strings in:
- `nix/packages/clawdbot-gateway.nix`
- `nix/checks/clawdbot-gateway-tests.nix`
- `nix/checks/clawdbot-config-options.nix`

This prevents CI failures caused by version mismatches between generated config options and the golden file during automated updates.

## Test plan
- [x] Built clawdbot-gateway package successfully
- [x] Integrated with nix-darwin/home-manager
- [x] darwin-rebuild switch completed
- [x] LaunchAgent running with correct nix paths
- [x] Gateway starts and connects to Telegram
- [x] Verified perl regex for version replacement works correctly
- [x] Verified bash syntax of update-pins.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)