### PR TITLE
fix: disable macOS-only first-party plugins by default on Linux

### DIFF
--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -2,7 +2,7 @@
 set -e
 mkdir -p "$out/lib/clawdbot" "$out/bin"
 
-cp -r dist node_modules package.json ui "$out/lib/clawdbot/"
+cp -r dist node_modules package.json ui extensions "$out/lib/clawdbot/"
 
 if [ -z "${STDENV_SETUP:-}" ]; then
   echo "STDENV_SETUP is not set" >&2

--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -2,7 +2,7 @@
 set -e
 mkdir -p "$out/lib/clawdbot" "$out/bin"
 
-cp -r dist node_modules package.json ui extensions "$out/lib/clawdbot/"
+cp -r dist node_modules package.json ui extensions docs "$out/lib/clawdbot/"
 
 if [ -z "${STDENV_SETUP:-}" ]; then
   echo "STDENV_SETUP is not set" >&2


### PR DESCRIPTION
## Summary

Fixes nix-clawdbot on Linux headless servers.

The module was failing on Linux because:
1. First-party plugins (peekaboo, summarize) defaulted to enabled but depend on macOS-only packages
2. The memory plugin doesn't exist on headless servers, causing "plugin not found: memory-core" error
3. Config schema was outdated (telegram → channels.telegram, byProvider → byChannel)
4. providers.anthropic.apiKeyFile was not included in generated config, causing "No API key found" error
