### PR TITLE
NixOS and aarch64-linux support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     let
       overlay = import ./nix/overlay.nix;
       sourceInfoStable = import ./nix/sources/clawdbot-source.nix;
-      systems = [ "x86_64-linux" "aarch64-darwin" ];
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
     in
     flake-utils.lib.eachSystem systems (system:
       let

--- a/nix/modules/home-manager/clawdbot.nix
+++ b/nix/modules/home-manager/clawdbot.nix
@@ -36,7 +36,7 @@ let
   };
 
   mkTelegramConfig = inst: lib.optionalAttrs inst.providers.telegram.enable {
-    telegram = {
+    channels.telegram = {
       enabled = true;
       tokenFile = inst.providers.telegram.botTokenFile;
       allowFrom = inst.providers.telegram.allowFrom;

--- a/nix/modules/home-manager/clawdbot.nix
+++ b/nix/modules/home-manager/clawdbot.nix
@@ -48,7 +48,7 @@ let
     messages = {
       queue = {
         mode = inst.routing.queue.mode;
-        byProvider = inst.routing.queue.byProvider;
+        byChannel = inst.routing.queue.byChannel;
       };
     };
   };
@@ -211,14 +211,14 @@ let
           description = "Queue mode when a run is active.";
         };
 
-        byProvider = lib.mkOption {
+        byChannel = lib.mkOption {
           type = lib.types.attrs;
           default = {
             telegram = "interrupt";
             discord = "queue";
             webchat = "queue";
           };
-          description = "Per-provider queue mode overrides.";
+          description = "Per-channel queue mode overrides.";
         };
       };
 
@@ -1089,17 +1089,16 @@ in {
         description = "Queue mode when a run is active.";
       };
 
-      byProvider = lib.mkOption {
+      byChannel = lib.mkOption {
         type = lib.types.attrs;
         default = {
           telegram = "interrupt";
           discord = "queue";
           webchat = "queue";
         };
-        description = "Per-provider queue mode overrides.";
+        description = "Per-channel queue mode overrides.";
       };
     };
-
 
     launchd.enable = lib.mkOption {
       type = lib.types.bool;

--- a/nix/modules/home-manager/clawdbot.nix
+++ b/nix/modules/home-manager/clawdbot.nix
@@ -1176,13 +1176,12 @@ in {
     );
 
     home.activation.clawdbotDirs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      /bin/mkdir -p ${lib.concatStringsSep " " (lib.concatMap (item: item.dirs) instanceConfigs)}
-      ${lib.optionalString (pluginStateDirsAll != []) "/bin/mkdir -p ${lib.concatStringsSep " " pluginStateDirsAll}"}
+      run mkdir -p ${lib.concatStringsSep " " (lib.concatMap (item: item.dirs) instanceConfigs)}
+      ${lib.optionalString (pluginStateDirsAll != []) "run mkdir -p ${lib.concatStringsSep " " pluginStateDirsAll}"}
     '';
 
     home.activation.clawdbotConfigFiles = lib.hm.dag.entryAfter [ "clawdbotDirs" ] ''
-      set -euo pipefail
-      ${lib.concatStringsSep "\n" (map (item: "/bin/ln -sfn ${item.configFile} ${item.configPath}") instanceConfigs)}
+      ${lib.concatStringsSep "\n" (map (item: "run ln -sfn ${item.configFile} ${item.configPath}") instanceConfigs)}
     '';
 
     home.activation.clawdbotPluginGuard = lib.hm.dag.entryAfter [ "writeBoundary" ] ''

--- a/nix/modules/home-manager/clawdbot.nix
+++ b/nix/modules/home-manager/clawdbot.nix
@@ -813,20 +813,20 @@ let
         };
         Service = {
           ExecStart = "${gatewayWrapper}/bin/clawdbot-gateway-${name} gateway --port ${toString inst.gatewayPort}";
-          WorkingDirectory = inst.stateDir;
+          WorkingDirectory = resolvePath inst.stateDir;
           Restart = "always";
           RestartSec = "1s";
           Environment = [
             "HOME=${homeDir}"
-            "CLAWDBOT_CONFIG_PATH=${inst.configPath}"
-            "CLAWDBOT_STATE_DIR=${inst.stateDir}"
+            "CLAWDBOT_CONFIG_PATH=${resolvePath inst.configPath}"
+            "CLAWDBOT_STATE_DIR=${resolvePath inst.stateDir}"
             "CLAWDBOT_NIX_MODE=1"
-            "CLAWDIS_CONFIG_PATH=${inst.configPath}"
-            "CLAWDIS_STATE_DIR=${inst.stateDir}"
+            "CLAWDIS_CONFIG_PATH=${resolvePath inst.configPath}"
+            "CLAWDIS_STATE_DIR=${resolvePath inst.stateDir}"
             "CLAWDIS_NIX_MODE=1"
           ];
-          StandardOutput = "append:${inst.logPath}";
-          StandardError = "append:${inst.logPath}";
+          StandardOutput = "append:${resolvePath inst.logPath}";
+          StandardError = "append:${resolvePath inst.logPath}";
         };
         Install = {
           WantedBy = [ "default.target" ];

--- a/nix/modules/home-manager/clawdbot.nix
+++ b/nix/modules/home-manager/clawdbot.nix
@@ -300,6 +300,8 @@ let
     configPath = "${cfg.stateDir}/clawdbot.json";
     logPath = "/tmp/clawdbot/clawdbot-gateway.log";
     gatewayPort = 18789;
+    gatewayPath = null;
+    gatewayPnpmDepsHash = lib.fakeHash;
     providers = cfg.providers;
     routing = cfg.routing;
     launchd = cfg.launchd;
@@ -307,6 +309,10 @@ let
     plugins = cfg.plugins;
     configOverrides = {};
     config = {};
+    agent = {
+      model = cfg.defaults.model;
+      thinkingDefault = cfg.defaults.thinkingDefault;
+    };
     appDefaults = {
       enable = true;
       attachExistingOnly = true;

--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -4,6 +4,10 @@ mkdir -p "$out/lib/clawdbot" "$out/bin"
 
 # Copy core files and bundled extensions (memory-core, etc.)
 cp -r dist node_modules package.json ui "$out/lib/clawdbot/"
+# Copy docs (includes workspace templates like AGENTS.md)
+if [ -d "docs" ]; then
+  cp -r docs "$out/lib/clawdbot/"
+fi
 if [ -d "extensions" ]; then
   cp -r extensions "$out/lib/clawdbot/"
 fi

--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -2,7 +2,11 @@
 set -e
 mkdir -p "$out/lib/clawdbot" "$out/bin"
 
+# Copy core files and bundled extensions (memory-core, etc.)
 cp -r dist node_modules package.json ui "$out/lib/clawdbot/"
+if [ -d "extensions" ]; then
+  cp -r extensions "$out/lib/clawdbot/"
+fi
 
 if [ -z "${STDENV_SETUP:-}" ]; then
   echo "STDENV_SETUP is not set" >&2
@@ -16,6 +20,14 @@ fi
 bash -e -c '. "$STDENV_SETUP"; patchShebangs "$out/lib/clawdbot/node_modules/.bin"'
 if [ -d "$out/lib/clawdbot/ui/node_modules/.bin" ]; then
   bash -e -c '. "$STDENV_SETUP"; patchShebangs "$out/lib/clawdbot/ui/node_modules/.bin"'
+fi
+# Patch shebangs in extensions node_modules if present
+if [ -d "$out/lib/clawdbot/extensions" ]; then
+  for ext_bin in "$out/lib/clawdbot/extensions"/*/node_modules/.bin; do
+    if [ -d "$ext_bin" ]; then
+      bash -e -c '. "$STDENV_SETUP"; patchShebangs "'"$ext_bin"'"'
+    fi
+  done
 fi
 
 # Work around missing dependency declaration in pi-coding-agent (strip-ansi).


### PR DESCRIPTION
## Summary

  This PR enables running clawdbot on NixOS systems, particularly aarch64-linux (tested on Hetzner CAX ARM servers).

  ### NixOS compatibility
  - Use portable home-manager activation scripts (`run` function instead of hardcoded `/bin/mkdir`) - addresses #5
  - Resolve `~` paths in systemd service config
  - Add missing instance config defaults for systemd services

  ### aarch64-linux support
  - Add `aarch64-linux` to supported systems in flake

  ### Upstream schema migrations
  - Move telegram config to `channels.telegram`
  - Rename `byProvider` to `byChannel` in routing queue options (similar to #9)

  ### Build fixes
  - Bundle extensions directory in gateway package
  - Include docs directory for workspace templates (AGENTS.md, etc.)

  ### CI improvements
  - Auto-update version strings in `update-pins.sh` (similar to #7)