### PR TITLE
chore: bump clawdbot to v2026.1.23

### DIFF
--- a/nix/packages/clawdbot-gateway.nix
+++ b/nix/packages/clawdbot-gateway.nix
@@ -38,7 +38,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "clawdbot-gateway";
-  version = "2026.1.8-2";
+  version = "2026.1.23";
 
   src = if gatewaySrc != null then gatewaySrc else fetchFromGitHub sourceFetch;
 

--- a/nix/sources/clawdbot-source.nix
+++ b/nix/sources/clawdbot-source.nix
@@ -2,7 +2,7 @@
 {
   owner = "clawdbot";
   repo = "clawdbot";
-  rev = "926c2647b8887f30a038dafdc52d6bbecf1b2fb4";
-  hash = "sha256-BlJSlZzYPplj97mg2Aap346g+2odv5os29IXaS0LpZs=";
-  pnpmDepsHash = "sha256-K4+HcH9fPExmRZxEDbH6bhYSggJN5AyR1tOd7toEZmg=";
+  rev = "c9e98376b3e5d3a2f3a1639be53bd850f6d3acbf";
+  hash = "sha256-egAHjt6CHz79fStSg42opVPHjquurAa6FcGpNkQ0UtA=";
+  pnpmDepsHash = "sha256-N0rAUNutQ/zox1ZL6Lt/lwvXoPc5mbmW5mw3f0fSuKw=";
 }


### PR DESCRIPTION
Bumps clawdbot to the latest release v2026.1.23.

Changes:
- Updated source hash to v2026.1.23 commit
- Updated pnpmDepsHash for fetcherVersion=2
- Updated version in clawdbot-gateway.nix