### PR TITLE
Allow local file management

### DIFF
--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -2,7 +2,7 @@
 set -e
 mkdir -p "$out/lib/clawdbot" "$out/bin"
 
-cp -r dist node_modules package.json ui "$out/lib/clawdbot/"
+cp -r dist node_modules package.json ui extensions "$out/lib/clawdbot/"
 
 if [ -z "${STDENV_SETUP:-}" ]; then
   echo "STDENV_SETUP is not set" >&2

--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -2,7 +2,7 @@
 set -e
 mkdir -p "$out/lib/clawdbot" "$out/bin"
 
-cp -r dist node_modules package.json ui extensions "$out/lib/clawdbot/"
+cp -r dist node_modules package.json ui extensions docs "$out/lib/clawdbot/"
 
 if [ -z "${STDENV_SETUP:-}" ]; then
   echo "STDENV_SETUP is not set" >&2


### PR DESCRIPTION
## Problem
By default, the `nix-clawdbot` Home Manager module manages all configuration and document files by symlinking them from the Nix store. This prevents the application from modifying its own configuration (e.g., during `onboard` or via UI) and makes it difficult for users to manually edit files in the workspace without changing their Nix configuration.

Users may want to manage configuration via Nix but let the bot manage its own documents, or vice versa.

## Solution
Added two new options to the Home Manager module:

1.  **`programs.clawdbot.manageConfig`** (default: `true`)
    - When `false`, the `clawdbot.json` configuration file is not managed or symlinked by Nix.
2.  **`programs.clawdbot.manageDocuments`** (default: `true`)
    - When `false`, document files, skill files, and plugin files in the workspace are not managed or symlinked by Nix.
    - Activation guards for documents and plugins are disabled.

This provides granular control over which parts of the Clawdbot workspace are managed declaratively via Nix and which are left to the application or manual management.

## Files Modified
- `nix/modules/home-manager/clawdbot.nix`

## Additional Info. This is based off this PR:
https://github.com/clawdbot/nix-clawdbot/pull/9