### PR TITLE
fix: remove nodejs from extended tools to prevent conflict

### DIFF
--- a/nix/tools/extended.nix
+++ b/nix/tools/extended.nix
@@ -18,7 +18,6 @@ let
   ensure = names: safe (map pick names);
 
   baseNames = [
-    "nodejs_22"
     "pnpm_10"
     "git"
     "curl"


### PR DESCRIPTION
## Summary

- Remove `nodejs_22` from the extended tools list to prevent conflicts with system-installed nodejs

## Problem

The clawdbot package bundles `nodejs_22` in its extended tools (`nix/tools/extended.nix`), which conflicts with system-installed nodejs when both are in `home.packages`:

```
pkgs.buildEnv error: two given paths contain a conflicting subpath:
  `/nix/store/...-nodejs-24.13.0/bin/node' and
  `/nix/store/...-clawdbot-2.0.0-beta5/bin/node'
```

## Solution

Remove `nodejs_22` from the `baseNames` list in `extended.nix`. The `clawdbot-gateway` wrapper already references node internally via `makeWrapper` with `$NODE_BIN`, so there's no need to expose node in the user's PATH through the tools bundle.

Clawdbot continues to work correctly because:
1. The gateway uses `makeWrapper` to reference nodejs internally
2. pnpm is still included for any npm-related tooling needs

Fixes #15