### PR TITLE
fix: include docs/reference/templates in clawdbot-gateway package

### DIFF
--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -4,6 +4,10 @@ mkdir -p "$out/lib/clawdbot" "$out/bin"
 
 cp -r dist node_modules package.json ui "$out/lib/clawdbot/"
 
+# Include workspace templates needed at runtime
+mkdir -p "$out/lib/clawdbot/docs/reference"
+cp -r docs/reference/templates "$out/lib/clawdbot/docs/reference/"
+
 if [ -z "${STDENV_SETUP:-}" ]; then
   echo "STDENV_SETUP is not set" >&2
   exit 1


### PR DESCRIPTION
## Summary

- Include the `docs/reference/templates` directory in the clawdbot-gateway Nix package

Fixes #18

## Problem

The templates directory was missing from the packaged output, causing runtime errors:

```
Error: Missing workspace template: AGENTS.md 
(/nix/store/.../lib/clawdbot/docs/reference/templates/AGENTS.md)
```

## Solution

Added the necessary `mkdir` and `cp` commands to `nix/scripts/gateway-install.sh` to include the templates directory in the package output.