### PR TITLE
fix: bundle all runtime assets (extensions, docs)

### DIFF
--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -2,10 +2,7 @@
 set -e
 mkdir -p "$out/lib/openclaw" "$out/bin"
 
-cp -r dist node_modules package.json ui "$out/lib/openclaw/"
-if [ -d extensions ]; then
-  cp -r extensions "$out/lib/openclaw/"
-fi
+cp -r dist node_modules package.json ui extensions docs "$out/lib/openclaw/"
 
 if [ -z "${STDENV_SETUP:-}" ]; then
   echo "STDENV_SETUP is not set" >&2


### PR DESCRIPTION
## Summary

Bundle `extensions/` and `docs/` in a single cp command alongside other runtime assets.

**Before:**
```sh
cp -r dist node_modules package.json ui "$out/lib/moltbot/"
if [ -d extensions ]; then
  cp -r extensions "$out/lib/moltbot/"
fi
```

**After:**
```sh
cp -r dist node_modules package.json ui extensions docs "$out/lib/moltbot/"
```

## Fixes

- Fixes #6 — Bug: extensions directory not included in package build
- Fixes #14 — extensions/ not bundled (plugin not found errors)
- Fixes #18 — docs/reference/templates not bundled (missing workspace template errors)

## Test plan

- [ ] Build gateway package
- [ ] Verify `extensions/` and `docs/reference/templates/` exist in output
- [ ] Run gateway with Telegram channel configured
- [ ] Confirm workspace bootstrapping works

---

🤖 Generated with [Claude Code](https://claude.ai/code)