### PR TITLE
Fix config schema alignment with openclaw

### DIFF
--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -2,10 +2,7 @@
 set -e
 mkdir -p "$out/lib/openclaw" "$out/bin"
 
-cp -r dist node_modules package.json ui "$out/lib/openclaw/"
-if [ -d extensions ]; then
-  cp -r extensions "$out/lib/openclaw/"
-fi
+cp -r dist node_modules package.json ui extensions docs "$out/lib/openclaw/"
 
 if [ -z "${STDENV_SETUP:-}" ]; then
   echo "STDENV_SETUP is not set" >&2


### PR DESCRIPTION
## Summary
Three fixes to align nix-clawbot with the openclaw config schema:

1. **byProvider → byChannel**: Queue config was using `messages.queue.byProvider` but openclaw expects `messages.queue.byChannel`

2. **telegram → channels.telegram**: Telegram config was generated at root level but openclaw expects it under `channels.telegram`

3. **gateway.auth.tokenFile**: Added new option to inject gateway auth token from a file at activation time, supporting proper secret management

## Fixes

- Fixes #33 — Module generates config keys rejected by OpenClaw 2026.1.29
- Fixes #17 — Generated config contains invalid key: messages.queue.byProvider

## Changes
- Renamed `byProvider` to `byChannel` in option definitions and `mkRoutingConfig`
- Updated `mkTelegramConfig` to generate `channels.telegram` instead of root-level `telegram`
- Added `gateway.auth.tokenFile` option at both global and instance levels
- Added `moltbotGatewayAuth` activation step to inject token from file

## Test plan
- [x] Build home-manager config with changes
- [x] Verify generated JSON contains `byChannel` instead of `byProvider`
- [x] Verify generated JSON contains `channels.telegram` instead of root-level `telegram`
- [x] Verify gateway token is injected from file during activation

🤖 Generated with [Claude Code](https://claude.com/claude-code)