### PR TITLE
fix: update nix-steipete-tools lock for openclawPlugin alias

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1769746835,
-        "narHash": "sha256-FO3GhjupUvNuNhZfHnl9bKGv9DSvSgGyHwptreFmzaY=",
+        "lastModified": 1769797395,
+        "narHash": "sha256-QkPl/Rgk9DXgaVNhjvHHHjy5e81j+MzcVOouZRdUTLA=",
         "owner": "openclaw",
         "repo": "nix-steipete-tools",
-        "rev": "04b5b4c39fc7c9811501ef74619c2aab52ab8891",
+        "rev": "dbf0a31a57407d9140e32357ea8d0215bd9feed9",
         "type": "github"
       },
       "original": {

--- a/nix/modules/home-manager/openclaw.nix
+++ b/nix/modules/home-manager/openclaw.nix
@@ -54,8 +54,8 @@ let
   };
 
   firstPartySources = let
-    stepieteRev = "e4e2cac265de35175015cf1ae836b0b30dddd7b7";
-    stepieteNarHash = "sha256-L8bKt5rK78dFP3ZoP1Oi1SSAforXVHZDsSiDO+NsvEE=";
+    stepieteRev = "e406b6dc7d066afd1a53bd125f079cf80435a813";
+    stepieteNarHash = "sha256-oytfuJiVrsFM4cQQLGyDp1/HlsihIOp++rIh2tThIZo=";
     stepiete = tool:
       "github:openclaw/nix-steipete-tools?dir=tools/${tool}&rev=${stepieteRev}&narHash=${stepieteNarHash}";
   in {


### PR DESCRIPTION
## Summary         
- Updates the hardcoded `stepieteRev` in `nix/modules/home-manager/openclaw.nix` from `e4e2cac` to `e406b6dc`, which includes the `openclawPlugin` alias needed by the oracle plugin and other first-party plugin sub-flakes. 

- Updates the top-level `flake.lock` to pin `nix-steipete-tools` to the latest revision (`dbf0a31`).                                                               
                                                                                           
## Context                                                                          
The oracle plugin (and other first-party plugins) reference `nix-steipete-tools` sub-flakes via `github:openclaw/nix-steipete-tools?dir=tools/<tool>&rev=<rev>`. The previous revision (`e4e2cac`) was missing the `openclawPlugin` attribute, causing         evaluation failures when enabling first-party plugins.                              
                                                                                           
## Test plan                                                                        
- [ ] Verify `nix flake check` passes                                               
- [ ] Verify `programs.openclaw.firstParty.oracle.enable = true` no longer throws `openclawPlugin missing` error                                               
                                                                                           
🤖 Generated with [Claude Code](https://claude.com/claude-code)