### PR TITLE
fix: remove messages.queue.byProvider rejected by OpenClaw 2026.1.29

### DIFF
--- a/nix/modules/home-manager/openclaw.nix
+++ b/nix/modules/home-manager/openclaw.nix
@@ -48,7 +48,6 @@ let
     messages = {
       queue = {
         mode = inst.routing.queue.mode;
-        byProvider = inst.routing.queue.byProvider;
       };
     };
   };
@@ -211,15 +210,6 @@ let
           description = "Queue mode when a run is active.";
         };
 
-        byProvider = lib.mkOption {
-          type = lib.types.attrs;
-          default = {
-            telegram = "interrupt";
-            discord = "queue";
-            webchat = "queue";
-          };
-          description = "Per-provider queue mode overrides.";
-        };
       };
 
       
@@ -1082,15 +1072,6 @@ in {
         description = "Queue mode when a run is active.";
       };
 
-      byProvider = lib.mkOption {
-        type = lib.types.attrs;
-        default = {
-          telegram = "interrupt";
-          discord = "queue";
-          webchat = "queue";
-        };
-        description = "Per-provider queue mode overrides.";
-      };
     };
 
 


### PR DESCRIPTION
## Summary
- Remove `messages.queue.byProvider` from generated config — upstream schema no longer accepts this key as of OpenClaw 2026.1.29
- Remove the `routing.queue.byProvider` option definition from both instance and top-level module options
- `routing.queue.mode` (still valid upstream) is preserved

Users needing per-channel queue overrides can use `configOverrides`:
```nix
configOverrides.messages.queue.byChannel.telegram = "interrupt";
```

## Test plan
- [x] `nix flake check --no-build` passes
- [x] Verified no remaining references to `byProvider` in module
- [x] Generated config no longer includes the rejected key

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)