### PR TITLE
feat: schema alignment & metadata-driven validation

### DIFF
--- a/nix/checks/openclaw-config-options.nix
+++ b/nix/checks/openclaw-config-options.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     STDENV_SETUP = "${stdenv}/setup";
     CONFIG_OPTIONS_GENERATOR = "${../scripts/generate-config-options.ts}";
     CONFIG_OPTIONS_GOLDEN = "${../generated/openclaw-config-options.nix}";
+    CONFIG_METADATA_GOLDEN = "${../generated/openclaw-config-metadata.json}";
     NODE_ENGINE_CHECK = "${../scripts/check-node-engine.ts}";
   };
 

--- a/nix/generated/openclaw-config-metadata.json
+++ b/nix/generated/openclaw-config-metadata.json
@@ -1,0 +1,10376 @@
+{
+  "version": "1.0",
+  "validPaths": {
+    "": [
+      "agents",
+      "approvals",
+      "audio",
+      "auth",
+      "bindings",
+      "broadcast",
+      "browser",
+      "canvasHost",
+      "channels",
+      "commands",
+      "cron",
+      "diagnostics",
+      "discovery",
+      "env",
+      "gateway",
+      "hooks",
+      "logging",
+      "media",
+      "messages",
+      "meta",
+      "models",
+      "nodeHost",
+      "plugins",
+      "session",
+      "skills",
+      "talk",
+      "tools",
+      "ui",
+      "update",
+      "web",
+      "wizard"
+    ],
+    "agents": [
+      "defaults",
+      "list"
+    ],
+    "agents.defaults": [
+      "blockStreamingBreak",
+      "blockStreamingChunk",
+      "blockStreamingCoalesce",
+      "blockStreamingDefault",
+      "bootstrapMaxChars",
+      "cliBackends",
+      "compaction",
+      "contextPruning",
+      "contextTokens",
+      "elevatedDefault",
+      "envelopeElapsed",
+      "envelopeTimestamp",
+      "envelopeTimezone",
+      "heartbeat",
+      "humanDelay",
+      "imageModel",
+      "maxConcurrent",
+      "mediaMaxMb",
+      "memorySearch",
+      "model",
+      "models",
+      "repoRoot",
+      "sandbox",
+      "skipBootstrap",
+      "subagents",
+      "thinkingDefault",
+      "timeFormat",
+      "timeoutSeconds",
+      "typingIntervalSeconds",
+      "typingMode",
+      "userTimezone",
+      "verboseDefault",
+      "workspace"
+    ],
+    "agents.defaults.blockStreamingChunk": [
+      "breakPreference",
+      "maxChars",
+      "minChars"
+    ],
+    "agents.defaults.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "agents.defaults.cliBackends.*": [
+      "args",
+      "clearEnv",
+      "command",
+      "env",
+      "imageArg",
+      "imageMode",
+      "input",
+      "maxPromptArgChars",
+      "modelAliases",
+      "modelArg",
+      "output",
+      "resumeArgs",
+      "resumeOutput",
+      "serialize",
+      "sessionArg",
+      "sessionArgs",
+      "sessionIdFields",
+      "sessionMode",
+      "systemPromptArg",
+      "systemPromptMode",
+      "systemPromptWhen"
+    ],
+    "agents.defaults.compaction": [
+      "maxHistoryShare",
+      "memoryFlush",
+      "mode",
+      "reserveTokensFloor"
+    ],
+    "agents.defaults.compaction.memoryFlush": [
+      "enabled",
+      "prompt",
+      "softThresholdTokens",
+      "systemPrompt"
+    ],
+    "agents.defaults.contextPruning": [
+      "hardClear",
+      "hardClearRatio",
+      "keepLastAssistants",
+      "minPrunableToolChars",
+      "mode",
+      "softTrim",
+      "softTrimRatio",
+      "tools",
+      "ttl"
+    ],
+    "agents.defaults.contextPruning.hardClear": [
+      "enabled",
+      "placeholder"
+    ],
+    "agents.defaults.contextPruning.softTrim": [
+      "headChars",
+      "maxChars",
+      "tailChars"
+    ],
+    "agents.defaults.contextPruning.tools": [
+      "allow",
+      "deny"
+    ],
+    "agents.defaults.heartbeat": [
+      "ackMaxChars",
+      "activeHours",
+      "every",
+      "includeReasoning",
+      "model",
+      "prompt",
+      "session",
+      "target",
+      "to"
+    ],
+    "agents.defaults.heartbeat.activeHours": [
+      "end",
+      "start",
+      "timezone"
+    ],
+    "agents.defaults.humanDelay": [
+      "maxMs",
+      "minMs",
+      "mode"
+    ],
+    "agents.defaults.imageModel": [
+      "fallbacks",
+      "primary"
+    ],
+    "agents.defaults.memorySearch": [
+      "cache",
+      "chunking",
+      "enabled",
+      "experimental",
+      "extraPaths",
+      "fallback",
+      "local",
+      "model",
+      "provider",
+      "query",
+      "remote",
+      "sources",
+      "store",
+      "sync"
+    ],
+    "agents.defaults.memorySearch.cache": [
+      "enabled",
+      "maxEntries"
+    ],
+    "agents.defaults.memorySearch.chunking": [
+      "overlap",
+      "tokens"
+    ],
+    "agents.defaults.memorySearch.experimental": [
+      "sessionMemory"
+    ],
+    "agents.defaults.memorySearch.local": [
+      "modelCacheDir",
+      "modelPath"
+    ],
+    "agents.defaults.memorySearch.query": [
+      "hybrid",
+      "maxResults",
+      "minScore"
+    ],
+    "agents.defaults.memorySearch.query.hybrid": [
+      "candidateMultiplier",
+      "enabled",
+      "textWeight",
+      "vectorWeight"
+    ],
+    "agents.defaults.memorySearch.remote": [
+      "apiKey",
+      "baseUrl",
+      "batch",
+      "headers"
+    ],
+    "agents.defaults.memorySearch.remote.batch": [
+      "concurrency",
+      "enabled",
+      "pollIntervalMs",
+      "timeoutMinutes",
+      "wait"
+    ],
+    "agents.defaults.memorySearch.store": [
+      "driver",
+      "path",
+      "vector"
+    ],
+    "agents.defaults.memorySearch.store.vector": [
+      "enabled",
+      "extensionPath"
+    ],
+    "agents.defaults.memorySearch.sync": [
+      "intervalMinutes",
+      "onSearch",
+      "onSessionStart",
+      "sessions",
+      "watch",
+      "watchDebounceMs"
+    ],
+    "agents.defaults.memorySearch.sync.sessions": [
+      "deltaBytes",
+      "deltaMessages"
+    ],
+    "agents.defaults.model": [
+      "fallbacks",
+      "primary"
+    ],
+    "agents.defaults.models.*": [
+      "alias",
+      "params"
+    ],
+    "agents.defaults.sandbox": [
+      "browser",
+      "docker",
+      "mode",
+      "perSession",
+      "prune",
+      "scope",
+      "sessionToolsVisibility",
+      "workspaceAccess",
+      "workspaceRoot"
+    ],
+    "agents.defaults.sandbox.browser": [
+      "allowHostControl",
+      "autoStart",
+      "autoStartTimeoutMs",
+      "cdpPort",
+      "containerPrefix",
+      "enableNoVnc",
+      "enabled",
+      "headless",
+      "image",
+      "noVncPort",
+      "vncPort"
+    ],
+    "agents.defaults.sandbox.docker": [
+      "apparmorProfile",
+      "binds",
+      "capDrop",
+      "containerPrefix",
+      "cpus",
+      "dns",
+      "env",
+      "extraHosts",
+      "image",
+      "memory",
+      "memorySwap",
+      "network",
+      "pidsLimit",
+      "readOnlyRoot",
+      "seccompProfile",
+      "setupCommand",
+      "tmpfs",
+      "ulimits",
+      "user",
+      "workdir"
+    ],
+    "agents.defaults.sandbox.prune": [
+      "idleHours",
+      "maxAgeDays"
+    ],
+    "agents.defaults.subagents": [
+      "archiveAfterMinutes",
+      "maxConcurrent",
+      "model"
+    ],
+    "approvals": [
+      "exec"
+    ],
+    "approvals.exec": [
+      "agentFilter",
+      "enabled",
+      "mode",
+      "sessionFilter",
+      "targets"
+    ],
+    "audio": [
+      "transcription"
+    ],
+    "audio.transcription": [
+      "command",
+      "timeoutSeconds"
+    ],
+    "auth": [
+      "cooldowns",
+      "order",
+      "profiles"
+    ],
+    "auth.cooldowns": [
+      "billingBackoffHours",
+      "billingBackoffHoursByProvider",
+      "billingMaxHours",
+      "failureWindowHours"
+    ],
+    "auth.profiles.*": [
+      "email",
+      "mode",
+      "provider"
+    ],
+    "broadcast": [
+      "strategy"
+    ],
+    "browser": [
+      "attachOnly",
+      "cdpUrl",
+      "color",
+      "defaultProfile",
+      "enabled",
+      "evaluateEnabled",
+      "executablePath",
+      "headless",
+      "noSandbox",
+      "profiles",
+      "remoteCdpHandshakeTimeoutMs",
+      "remoteCdpTimeoutMs",
+      "snapshotDefaults"
+    ],
+    "browser.profiles.*": [
+      "cdpPort",
+      "cdpUrl",
+      "color",
+      "driver"
+    ],
+    "browser.snapshotDefaults": [
+      "mode"
+    ],
+    "canvasHost": [
+      "enabled",
+      "liveReload",
+      "port",
+      "root"
+    ],
+    "channels": [
+      "bluebubbles",
+      "defaults",
+      "discord",
+      "googlechat",
+      "imessage",
+      "msteams",
+      "signal",
+      "slack",
+      "telegram",
+      "whatsapp"
+    ],
+    "channels.bluebubbles": [
+      "accounts",
+      "actions",
+      "allowFrom",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "capabilities",
+      "chunkMode",
+      "configWrites",
+      "dmHistoryLimit",
+      "dmPolicy",
+      "dms",
+      "enabled",
+      "groupAllowFrom",
+      "groupPolicy",
+      "groups",
+      "heartbeat",
+      "historyLimit",
+      "markdown",
+      "mediaMaxMb",
+      "name",
+      "password",
+      "sendReadReceipts",
+      "serverUrl",
+      "textChunkLimit",
+      "webhookPath"
+    ],
+    "channels.bluebubbles.accounts.*": [
+      "allowFrom",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "capabilities",
+      "chunkMode",
+      "configWrites",
+      "dmHistoryLimit",
+      "dmPolicy",
+      "dms",
+      "enabled",
+      "groupAllowFrom",
+      "groupPolicy",
+      "groups",
+      "heartbeat",
+      "historyLimit",
+      "markdown",
+      "mediaMaxMb",
+      "name",
+      "password",
+      "sendReadReceipts",
+      "serverUrl",
+      "textChunkLimit",
+      "webhookPath"
+    ],
+    "channels.bluebubbles.accounts.*.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.bluebubbles.accounts.*.dms.*": [
+      "historyLimit"
+    ],
+    "channels.bluebubbles.accounts.*.groups.*": [
+      "requireMention",
+      "tools",
+      "toolsBySender"
+    ],
+    "channels.bluebubbles.accounts.*.groups.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.bluebubbles.accounts.*.groups.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.bluebubbles.accounts.*.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.bluebubbles.accounts.*.markdown": [
+      "tables"
+    ],
+    "channels.bluebubbles.actions": [
+      "addParticipant",
+      "edit",
+      "leaveGroup",
+      "reactions",
+      "removeParticipant",
+      "renameGroup",
+      "reply",
+      "sendAttachment",
+      "sendWithEffect",
+      "setGroupIcon",
+      "unsend"
+    ],
+    "channels.bluebubbles.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.bluebubbles.dms.*": [
+      "historyLimit"
+    ],
+    "channels.bluebubbles.groups.*": [
+      "requireMention",
+      "tools",
+      "toolsBySender"
+    ],
+    "channels.bluebubbles.groups.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.bluebubbles.groups.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.bluebubbles.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.bluebubbles.markdown": [
+      "tables"
+    ],
+    "channels.defaults": [
+      "groupPolicy",
+      "heartbeat"
+    ],
+    "channels.defaults.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.discord": [
+      "accounts",
+      "actions",
+      "allowBots",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "capabilities",
+      "chunkMode",
+      "commands",
+      "configWrites",
+      "dm",
+      "dmHistoryLimit",
+      "dms",
+      "enabled",
+      "execApprovals",
+      "groupPolicy",
+      "guilds",
+      "heartbeat",
+      "historyLimit",
+      "intents",
+      "markdown",
+      "maxLinesPerMessage",
+      "mediaMaxMb",
+      "name",
+      "replyToMode",
+      "retry",
+      "textChunkLimit",
+      "token"
+    ],
+    "channels.discord.accounts.*": [
+      "actions",
+      "allowBots",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "capabilities",
+      "chunkMode",
+      "commands",
+      "configWrites",
+      "dm",
+      "dmHistoryLimit",
+      "dms",
+      "enabled",
+      "execApprovals",
+      "groupPolicy",
+      "guilds",
+      "heartbeat",
+      "historyLimit",
+      "intents",
+      "markdown",
+      "maxLinesPerMessage",
+      "mediaMaxMb",
+      "name",
+      "replyToMode",
+      "retry",
+      "textChunkLimit",
+      "token"
+    ],
+    "channels.discord.accounts.*.actions": [
+      "channelInfo",
+      "channels",
+      "emojiUploads",
+      "events",
+      "memberInfo",
+      "messages",
+      "moderation",
+      "permissions",
+      "pins",
+      "polls",
+      "reactions",
+      "roleInfo",
+      "roles",
+      "search",
+      "stickerUploads",
+      "stickers",
+      "threads",
+      "voiceStatus"
+    ],
+    "channels.discord.accounts.*.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.discord.accounts.*.commands": [
+      "native",
+      "nativeSkills"
+    ],
+    "channels.discord.accounts.*.dm": [
+      "allowFrom",
+      "enabled",
+      "groupChannels",
+      "groupEnabled",
+      "policy"
+    ],
+    "channels.discord.accounts.*.dms.*": [
+      "historyLimit"
+    ],
+    "channels.discord.accounts.*.execApprovals": [
+      "agentFilter",
+      "approvers",
+      "enabled",
+      "sessionFilter"
+    ],
+    "channels.discord.accounts.*.guilds.*": [
+      "channels",
+      "reactionNotifications",
+      "requireMention",
+      "slug",
+      "tools",
+      "toolsBySender",
+      "users"
+    ],
+    "channels.discord.accounts.*.guilds.*.channels.*": [
+      "allow",
+      "autoThread",
+      "enabled",
+      "requireMention",
+      "skills",
+      "systemPrompt",
+      "tools",
+      "toolsBySender",
+      "users"
+    ],
+    "channels.discord.accounts.*.guilds.*.channels.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.discord.accounts.*.guilds.*.channels.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.discord.accounts.*.guilds.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.discord.accounts.*.guilds.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.discord.accounts.*.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.discord.accounts.*.intents": [
+      "guildMembers",
+      "presence"
+    ],
+    "channels.discord.accounts.*.markdown": [
+      "tables"
+    ],
+    "channels.discord.accounts.*.retry": [
+      "attempts",
+      "jitter",
+      "maxDelayMs",
+      "minDelayMs"
+    ],
+    "channels.discord.actions": [
+      "channelInfo",
+      "channels",
+      "emojiUploads",
+      "events",
+      "memberInfo",
+      "messages",
+      "moderation",
+      "permissions",
+      "pins",
+      "polls",
+      "reactions",
+      "roleInfo",
+      "roles",
+      "search",
+      "stickerUploads",
+      "stickers",
+      "threads",
+      "voiceStatus"
+    ],
+    "channels.discord.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.discord.commands": [
+      "native",
+      "nativeSkills"
+    ],
+    "channels.discord.dm": [
+      "allowFrom",
+      "enabled",
+      "groupChannels",
+      "groupEnabled",
+      "policy"
+    ],
+    "channels.discord.dms.*": [
+      "historyLimit"
+    ],
+    "channels.discord.execApprovals": [
+      "agentFilter",
+      "approvers",
+      "enabled",
+      "sessionFilter"
+    ],
+    "channels.discord.guilds.*": [
+      "channels",
+      "reactionNotifications",
+      "requireMention",
+      "slug",
+      "tools",
+      "toolsBySender",
+      "users"
+    ],
+    "channels.discord.guilds.*.channels.*": [
+      "allow",
+      "autoThread",
+      "enabled",
+      "requireMention",
+      "skills",
+      "systemPrompt",
+      "tools",
+      "toolsBySender",
+      "users"
+    ],
+    "channels.discord.guilds.*.channels.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.discord.guilds.*.channels.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.discord.guilds.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.discord.guilds.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.discord.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.discord.intents": [
+      "guildMembers",
+      "presence"
+    ],
+    "channels.discord.markdown": [
+      "tables"
+    ],
+    "channels.discord.retry": [
+      "attempts",
+      "jitter",
+      "maxDelayMs",
+      "minDelayMs"
+    ],
+    "channels.googlechat": [
+      "accounts",
+      "actions",
+      "allowBots",
+      "audience",
+      "audienceType",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "botUser",
+      "capabilities",
+      "chunkMode",
+      "configWrites",
+      "defaultAccount",
+      "dm",
+      "dmHistoryLimit",
+      "dms",
+      "enabled",
+      "groupAllowFrom",
+      "groupPolicy",
+      "groups",
+      "historyLimit",
+      "mediaMaxMb",
+      "name",
+      "replyToMode",
+      "requireMention",
+      "serviceAccount",
+      "serviceAccountFile",
+      "textChunkLimit",
+      "typingIndicator",
+      "webhookPath",
+      "webhookUrl"
+    ],
+    "channels.googlechat.accounts.*": [
+      "actions",
+      "allowBots",
+      "audience",
+      "audienceType",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "botUser",
+      "capabilities",
+      "chunkMode",
+      "configWrites",
+      "dm",
+      "dmHistoryLimit",
+      "dms",
+      "enabled",
+      "groupAllowFrom",
+      "groupPolicy",
+      "groups",
+      "historyLimit",
+      "mediaMaxMb",
+      "name",
+      "replyToMode",
+      "requireMention",
+      "serviceAccount",
+      "serviceAccountFile",
+      "textChunkLimit",
+      "typingIndicator",
+      "webhookPath",
+      "webhookUrl"
+    ],
+    "channels.googlechat.accounts.*.actions": [
+      "reactions"
+    ],
+    "channels.googlechat.accounts.*.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.googlechat.accounts.*.dm": [
+      "allowFrom",
+      "enabled",
+      "policy"
+    ],
+    "channels.googlechat.accounts.*.dms.*": [
+      "historyLimit"
+    ],
+    "channels.googlechat.accounts.*.groups.*": [
+      "allow",
+      "enabled",
+      "requireMention",
+      "systemPrompt",
+      "users"
+    ],
+    "channels.googlechat.actions": [
+      "reactions"
+    ],
+    "channels.googlechat.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.googlechat.dm": [
+      "allowFrom",
+      "enabled",
+      "policy"
+    ],
+    "channels.googlechat.dms.*": [
+      "historyLimit"
+    ],
+    "channels.googlechat.groups.*": [
+      "allow",
+      "enabled",
+      "requireMention",
+      "systemPrompt",
+      "users"
+    ],
+    "channels.imessage": [
+      "accounts",
+      "allowFrom",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "capabilities",
+      "chunkMode",
+      "cliPath",
+      "configWrites",
+      "dbPath",
+      "dmHistoryLimit",
+      "dmPolicy",
+      "dms",
+      "enabled",
+      "groupAllowFrom",
+      "groupPolicy",
+      "groups",
+      "heartbeat",
+      "historyLimit",
+      "includeAttachments",
+      "markdown",
+      "mediaMaxMb",
+      "name",
+      "region",
+      "remoteHost",
+      "service",
+      "textChunkLimit"
+    ],
+    "channels.imessage.accounts.*": [
+      "allowFrom",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "capabilities",
+      "chunkMode",
+      "cliPath",
+      "configWrites",
+      "dbPath",
+      "dmHistoryLimit",
+      "dmPolicy",
+      "dms",
+      "enabled",
+      "groupAllowFrom",
+      "groupPolicy",
+      "groups",
+      "heartbeat",
+      "historyLimit",
+      "includeAttachments",
+      "markdown",
+      "mediaMaxMb",
+      "name",
+      "region",
+      "remoteHost",
+      "service",
+      "textChunkLimit"
+    ],
+    "channels.imessage.accounts.*.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.imessage.accounts.*.dms.*": [
+      "historyLimit"
+    ],
+    "channels.imessage.accounts.*.groups.*": [
+      "requireMention",
+      "tools",
+      "toolsBySender"
+    ],
+    "channels.imessage.accounts.*.groups.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.imessage.accounts.*.groups.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.imessage.accounts.*.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.imessage.accounts.*.markdown": [
+      "tables"
+    ],
+    "channels.imessage.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.imessage.dms.*": [
+      "historyLimit"
+    ],
+    "channels.imessage.groups.*": [
+      "requireMention",
+      "tools",
+      "toolsBySender"
+    ],
+    "channels.imessage.groups.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.imessage.groups.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.imessage.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.imessage.markdown": [
+      "tables"
+    ],
+    "channels.msteams": [
+      "allowFrom",
+      "appId",
+      "appPassword",
+      "blockStreamingCoalesce",
+      "capabilities",
+      "chunkMode",
+      "configWrites",
+      "dmHistoryLimit",
+      "dmPolicy",
+      "dms",
+      "enabled",
+      "groupAllowFrom",
+      "groupPolicy",
+      "heartbeat",
+      "historyLimit",
+      "markdown",
+      "mediaAllowHosts",
+      "mediaMaxMb",
+      "replyStyle",
+      "requireMention",
+      "sharePointSiteId",
+      "teams",
+      "tenantId",
+      "textChunkLimit",
+      "webhook"
+    ],
+    "channels.msteams.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.msteams.dms.*": [
+      "historyLimit"
+    ],
+    "channels.msteams.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.msteams.markdown": [
+      "tables"
+    ],
+    "channels.msteams.teams.*": [
+      "channels",
+      "replyStyle",
+      "requireMention",
+      "tools",
+      "toolsBySender"
+    ],
+    "channels.msteams.teams.*.channels.*": [
+      "replyStyle",
+      "requireMention",
+      "tools",
+      "toolsBySender"
+    ],
+    "channels.msteams.teams.*.channels.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.msteams.teams.*.channels.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.msteams.teams.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.msteams.teams.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.msteams.webhook": [
+      "path",
+      "port"
+    ],
+    "channels.signal": [
+      "account",
+      "accounts",
+      "actions",
+      "allowFrom",
+      "autoStart",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "capabilities",
+      "chunkMode",
+      "cliPath",
+      "configWrites",
+      "dmHistoryLimit",
+      "dmPolicy",
+      "dms",
+      "enabled",
+      "groupAllowFrom",
+      "groupPolicy",
+      "heartbeat",
+      "historyLimit",
+      "httpHost",
+      "httpPort",
+      "httpUrl",
+      "ignoreAttachments",
+      "ignoreStories",
+      "markdown",
+      "mediaMaxMb",
+      "name",
+      "reactionAllowlist",
+      "reactionLevel",
+      "reactionNotifications",
+      "receiveMode",
+      "sendReadReceipts",
+      "startupTimeoutMs",
+      "textChunkLimit"
+    ],
+    "channels.signal.accounts.*": [
+      "account",
+      "actions",
+      "allowFrom",
+      "autoStart",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "capabilities",
+      "chunkMode",
+      "cliPath",
+      "configWrites",
+      "dmHistoryLimit",
+      "dmPolicy",
+      "dms",
+      "enabled",
+      "groupAllowFrom",
+      "groupPolicy",
+      "heartbeat",
+      "historyLimit",
+      "httpHost",
+      "httpPort",
+      "httpUrl",
+      "ignoreAttachments",
+      "ignoreStories",
+      "markdown",
+      "mediaMaxMb",
+      "name",
+      "reactionAllowlist",
+      "reactionLevel",
+      "reactionNotifications",
+      "receiveMode",
+      "sendReadReceipts",
+      "startupTimeoutMs",
+      "textChunkLimit"
+    ],
+    "channels.signal.accounts.*.actions": [
+      "reactions"
+    ],
+    "channels.signal.accounts.*.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.signal.accounts.*.dms.*": [
+      "historyLimit"
+    ],
+    "channels.signal.accounts.*.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.signal.accounts.*.markdown": [
+      "tables"
+    ],
+    "channels.signal.actions": [
+      "reactions"
+    ],
+    "channels.signal.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.signal.dms.*": [
+      "historyLimit"
+    ],
+    "channels.signal.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.signal.markdown": [
+      "tables"
+    ],
+    "channels.slack": [
+      "accounts",
+      "actions",
+      "allowBots",
+      "appToken",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "botToken",
+      "capabilities",
+      "channels",
+      "chunkMode",
+      "commands",
+      "configWrites",
+      "dm",
+      "dmHistoryLimit",
+      "dms",
+      "enabled",
+      "groupPolicy",
+      "heartbeat",
+      "historyLimit",
+      "markdown",
+      "mediaMaxMb",
+      "mode",
+      "name",
+      "reactionAllowlist",
+      "reactionNotifications",
+      "replyToMode",
+      "replyToModeByChatType",
+      "requireMention",
+      "signingSecret",
+      "slashCommand",
+      "textChunkLimit",
+      "thread",
+      "userToken",
+      "userTokenReadOnly",
+      "webhookPath"
+    ],
+    "channels.slack.accounts.*": [
+      "actions",
+      "allowBots",
+      "appToken",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "botToken",
+      "capabilities",
+      "channels",
+      "chunkMode",
+      "commands",
+      "configWrites",
+      "dm",
+      "dmHistoryLimit",
+      "dms",
+      "enabled",
+      "groupPolicy",
+      "heartbeat",
+      "historyLimit",
+      "markdown",
+      "mediaMaxMb",
+      "mode",
+      "name",
+      "reactionAllowlist",
+      "reactionNotifications",
+      "replyToMode",
+      "replyToModeByChatType",
+      "requireMention",
+      "signingSecret",
+      "slashCommand",
+      "textChunkLimit",
+      "thread",
+      "userToken",
+      "userTokenReadOnly",
+      "webhookPath"
+    ],
+    "channels.slack.accounts.*.actions": [
+      "channelInfo",
+      "emojiList",
+      "memberInfo",
+      "messages",
+      "permissions",
+      "pins",
+      "reactions",
+      "search"
+    ],
+    "channels.slack.accounts.*.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.slack.accounts.*.channels.*": [
+      "allow",
+      "allowBots",
+      "enabled",
+      "requireMention",
+      "skills",
+      "systemPrompt",
+      "tools",
+      "toolsBySender",
+      "users"
+    ],
+    "channels.slack.accounts.*.channels.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.slack.accounts.*.channels.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.slack.accounts.*.commands": [
+      "native",
+      "nativeSkills"
+    ],
+    "channels.slack.accounts.*.dm": [
+      "allowFrom",
+      "enabled",
+      "groupChannels",
+      "groupEnabled",
+      "policy",
+      "replyToMode"
+    ],
+    "channels.slack.accounts.*.dms.*": [
+      "historyLimit"
+    ],
+    "channels.slack.accounts.*.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.slack.accounts.*.markdown": [
+      "tables"
+    ],
+    "channels.slack.accounts.*.replyToModeByChatType": [
+      "channel",
+      "direct",
+      "group"
+    ],
+    "channels.slack.accounts.*.slashCommand": [
+      "enabled",
+      "ephemeral",
+      "name",
+      "sessionPrefix"
+    ],
+    "channels.slack.accounts.*.thread": [
+      "historyScope",
+      "inheritParent"
+    ],
+    "channels.slack.actions": [
+      "channelInfo",
+      "emojiList",
+      "memberInfo",
+      "messages",
+      "permissions",
+      "pins",
+      "reactions",
+      "search"
+    ],
+    "channels.slack.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.slack.channels.*": [
+      "allow",
+      "allowBots",
+      "enabled",
+      "requireMention",
+      "skills",
+      "systemPrompt",
+      "tools",
+      "toolsBySender",
+      "users"
+    ],
+    "channels.slack.channels.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.slack.channels.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.slack.commands": [
+      "native",
+      "nativeSkills"
+    ],
+    "channels.slack.dm": [
+      "allowFrom",
+      "enabled",
+      "groupChannels",
+      "groupEnabled",
+      "policy",
+      "replyToMode"
+    ],
+    "channels.slack.dms.*": [
+      "historyLimit"
+    ],
+    "channels.slack.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.slack.markdown": [
+      "tables"
+    ],
+    "channels.slack.replyToModeByChatType": [
+      "channel",
+      "direct",
+      "group"
+    ],
+    "channels.slack.slashCommand": [
+      "enabled",
+      "ephemeral",
+      "name",
+      "sessionPrefix"
+    ],
+    "channels.slack.thread": [
+      "historyScope",
+      "inheritParent"
+    ],
+    "channels.telegram": [
+      "accounts",
+      "actions",
+      "allowFrom",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "botToken",
+      "capabilities",
+      "chunkMode",
+      "commands",
+      "configWrites",
+      "customCommands",
+      "dmHistoryLimit",
+      "dmPolicy",
+      "dms",
+      "draftChunk",
+      "enabled",
+      "groupAllowFrom",
+      "groupPolicy",
+      "groups",
+      "heartbeat",
+      "historyLimit",
+      "linkPreview",
+      "markdown",
+      "mediaMaxMb",
+      "name",
+      "network",
+      "proxy",
+      "reactionLevel",
+      "reactionNotifications",
+      "replyToMode",
+      "retry",
+      "streamMode",
+      "textChunkLimit",
+      "timeoutSeconds",
+      "tokenFile",
+      "webhookPath",
+      "webhookSecret",
+      "webhookUrl"
+    ],
+    "channels.telegram.accounts.*": [
+      "actions",
+      "allowFrom",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "botToken",
+      "capabilities",
+      "chunkMode",
+      "commands",
+      "configWrites",
+      "customCommands",
+      "dmHistoryLimit",
+      "dmPolicy",
+      "dms",
+      "draftChunk",
+      "enabled",
+      "groupAllowFrom",
+      "groupPolicy",
+      "groups",
+      "heartbeat",
+      "historyLimit",
+      "linkPreview",
+      "markdown",
+      "mediaMaxMb",
+      "name",
+      "network",
+      "proxy",
+      "reactionLevel",
+      "reactionNotifications",
+      "replyToMode",
+      "retry",
+      "streamMode",
+      "textChunkLimit",
+      "timeoutSeconds",
+      "tokenFile",
+      "webhookPath",
+      "webhookSecret",
+      "webhookUrl"
+    ],
+    "channels.telegram.accounts.*.actions": [
+      "deleteMessage",
+      "reactions",
+      "sendMessage",
+      "sticker"
+    ],
+    "channels.telegram.accounts.*.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.telegram.accounts.*.commands": [
+      "native",
+      "nativeSkills"
+    ],
+    "channels.telegram.accounts.*.dms.*": [
+      "historyLimit"
+    ],
+    "channels.telegram.accounts.*.draftChunk": [
+      "breakPreference",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.telegram.accounts.*.groups.*": [
+      "allowFrom",
+      "enabled",
+      "requireMention",
+      "skills",
+      "systemPrompt",
+      "tools",
+      "toolsBySender",
+      "topics"
+    ],
+    "channels.telegram.accounts.*.groups.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.telegram.accounts.*.groups.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.telegram.accounts.*.groups.*.topics.*": [
+      "allowFrom",
+      "enabled",
+      "requireMention",
+      "skills",
+      "systemPrompt"
+    ],
+    "channels.telegram.accounts.*.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.telegram.accounts.*.markdown": [
+      "tables"
+    ],
+    "channels.telegram.accounts.*.network": [
+      "autoSelectFamily"
+    ],
+    "channels.telegram.accounts.*.retry": [
+      "attempts",
+      "jitter",
+      "maxDelayMs",
+      "minDelayMs"
+    ],
+    "channels.telegram.actions": [
+      "deleteMessage",
+      "reactions",
+      "sendMessage",
+      "sticker"
+    ],
+    "channels.telegram.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.telegram.commands": [
+      "native",
+      "nativeSkills"
+    ],
+    "channels.telegram.dms.*": [
+      "historyLimit"
+    ],
+    "channels.telegram.draftChunk": [
+      "breakPreference",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.telegram.groups.*": [
+      "allowFrom",
+      "enabled",
+      "requireMention",
+      "skills",
+      "systemPrompt",
+      "tools",
+      "toolsBySender",
+      "topics"
+    ],
+    "channels.telegram.groups.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.telegram.groups.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.telegram.groups.*.topics.*": [
+      "allowFrom",
+      "enabled",
+      "requireMention",
+      "skills",
+      "systemPrompt"
+    ],
+    "channels.telegram.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.telegram.markdown": [
+      "tables"
+    ],
+    "channels.telegram.network": [
+      "autoSelectFamily"
+    ],
+    "channels.telegram.retry": [
+      "attempts",
+      "jitter",
+      "maxDelayMs",
+      "minDelayMs"
+    ],
+    "channels.whatsapp": [
+      "accounts",
+      "ackReaction",
+      "actions",
+      "allowFrom",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "capabilities",
+      "chunkMode",
+      "configWrites",
+      "debounceMs",
+      "dmHistoryLimit",
+      "dmPolicy",
+      "dms",
+      "groupAllowFrom",
+      "groupPolicy",
+      "groups",
+      "heartbeat",
+      "historyLimit",
+      "markdown",
+      "mediaMaxMb",
+      "messagePrefix",
+      "selfChatMode",
+      "sendReadReceipts",
+      "textChunkLimit"
+    ],
+    "channels.whatsapp.accounts.*": [
+      "ackReaction",
+      "allowFrom",
+      "authDir",
+      "blockStreaming",
+      "blockStreamingCoalesce",
+      "capabilities",
+      "chunkMode",
+      "configWrites",
+      "debounceMs",
+      "dmHistoryLimit",
+      "dmPolicy",
+      "dms",
+      "enabled",
+      "groupAllowFrom",
+      "groupPolicy",
+      "groups",
+      "heartbeat",
+      "historyLimit",
+      "markdown",
+      "mediaMaxMb",
+      "messagePrefix",
+      "name",
+      "selfChatMode",
+      "sendReadReceipts",
+      "textChunkLimit"
+    ],
+    "channels.whatsapp.accounts.*.ackReaction": [
+      "direct",
+      "emoji",
+      "group"
+    ],
+    "channels.whatsapp.accounts.*.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.whatsapp.accounts.*.dms.*": [
+      "historyLimit"
+    ],
+    "channels.whatsapp.accounts.*.groups.*": [
+      "requireMention",
+      "tools",
+      "toolsBySender"
+    ],
+    "channels.whatsapp.accounts.*.groups.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.whatsapp.accounts.*.groups.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.whatsapp.accounts.*.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.whatsapp.accounts.*.markdown": [
+      "tables"
+    ],
+    "channels.whatsapp.ackReaction": [
+      "direct",
+      "emoji",
+      "group"
+    ],
+    "channels.whatsapp.actions": [
+      "polls",
+      "reactions",
+      "sendMessage"
+    ],
+    "channels.whatsapp.blockStreamingCoalesce": [
+      "idleMs",
+      "maxChars",
+      "minChars"
+    ],
+    "channels.whatsapp.dms.*": [
+      "historyLimit"
+    ],
+    "channels.whatsapp.groups.*": [
+      "requireMention",
+      "tools",
+      "toolsBySender"
+    ],
+    "channels.whatsapp.groups.*.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.whatsapp.groups.*.toolsBySender.*": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "channels.whatsapp.heartbeat": [
+      "showAlerts",
+      "showOk",
+      "useIndicator"
+    ],
+    "channels.whatsapp.markdown": [
+      "tables"
+    ],
+    "commands": [
+      "bash",
+      "bashForegroundMs",
+      "config",
+      "debug",
+      "native",
+      "nativeSkills",
+      "restart",
+      "text",
+      "useAccessGroups"
+    ],
+    "cron": [
+      "enabled",
+      "maxConcurrentRuns",
+      "store"
+    ],
+    "diagnostics": [
+      "cacheTrace",
+      "enabled",
+      "flags",
+      "otel"
+    ],
+    "diagnostics.cacheTrace": [
+      "enabled",
+      "filePath",
+      "includeMessages",
+      "includePrompt",
+      "includeSystem"
+    ],
+    "diagnostics.otel": [
+      "enabled",
+      "endpoint",
+      "flushIntervalMs",
+      "headers",
+      "logs",
+      "metrics",
+      "protocol",
+      "sampleRate",
+      "serviceName",
+      "traces"
+    ],
+    "discovery": [
+      "mdns",
+      "wideArea"
+    ],
+    "discovery.mdns": [
+      "mode"
+    ],
+    "discovery.wideArea": [
+      "domain",
+      "enabled"
+    ],
+    "env": [
+      "shellEnv",
+      "vars"
+    ],
+    "env.shellEnv": [
+      "enabled",
+      "timeoutMs"
+    ],
+    "gateway": [
+      "auth",
+      "bind",
+      "controlUi",
+      "http",
+      "mode",
+      "nodes",
+      "port",
+      "reload",
+      "remote",
+      "tailscale",
+      "tls",
+      "trustedProxies"
+    ],
+    "gateway.auth": [
+      "allowTailscale",
+      "mode",
+      "password",
+      "token"
+    ],
+    "gateway.controlUi": [
+      "allowInsecureAuth",
+      "basePath",
+      "dangerouslyDisableDeviceAuth",
+      "enabled"
+    ],
+    "gateway.http": [
+      "endpoints"
+    ],
+    "gateway.http.endpoints": [
+      "chatCompletions",
+      "responses"
+    ],
+    "gateway.http.endpoints.chatCompletions": [
+      "enabled"
+    ],
+    "gateway.http.endpoints.responses": [
+      "enabled",
+      "files",
+      "images",
+      "maxBodyBytes"
+    ],
+    "gateway.http.endpoints.responses.files": [
+      "allowUrl",
+      "allowedMimes",
+      "maxBytes",
+      "maxChars",
+      "maxRedirects",
+      "pdf",
+      "timeoutMs"
+    ],
+    "gateway.http.endpoints.responses.files.pdf": [
+      "maxPages",
+      "maxPixels",
+      "minTextChars"
+    ],
+    "gateway.http.endpoints.responses.images": [
+      "allowUrl",
+      "allowedMimes",
+      "maxBytes",
+      "maxRedirects",
+      "timeoutMs"
+    ],
+    "gateway.nodes": [
+      "allowCommands",
+      "browser",
+      "denyCommands"
+    ],
+    "gateway.nodes.browser": [
+      "mode",
+      "node"
+    ],
+    "gateway.reload": [
+      "debounceMs",
+      "mode"
+    ],
+    "gateway.remote": [
+      "password",
+      "sshIdentity",
+      "sshTarget",
+      "tlsFingerprint",
+      "token",
+      "transport",
+      "url"
+    ],
+    "gateway.tailscale": [
+      "mode",
+      "resetOnExit"
+    ],
+    "gateway.tls": [
+      "autoGenerate",
+      "caPath",
+      "certPath",
+      "enabled",
+      "keyPath"
+    ],
+    "hooks": [
+      "enabled",
+      "gmail",
+      "internal",
+      "mappings",
+      "maxBodyBytes",
+      "path",
+      "presets",
+      "token",
+      "transformsDir"
+    ],
+    "hooks.gmail": [
+      "account",
+      "allowUnsafeExternalContent",
+      "hookUrl",
+      "includeBody",
+      "label",
+      "maxBytes",
+      "model",
+      "pushToken",
+      "renewEveryMinutes",
+      "serve",
+      "subscription",
+      "tailscale",
+      "thinking",
+      "topic"
+    ],
+    "hooks.gmail.serve": [
+      "bind",
+      "path",
+      "port"
+    ],
+    "hooks.gmail.tailscale": [
+      "mode",
+      "path",
+      "target"
+    ],
+    "hooks.internal": [
+      "enabled",
+      "entries",
+      "handlers",
+      "installs",
+      "load"
+    ],
+    "hooks.internal.entries.*": [
+      "enabled",
+      "env"
+    ],
+    "hooks.internal.installs.*": [
+      "hooks",
+      "installPath",
+      "installedAt",
+      "source",
+      "sourcePath",
+      "spec",
+      "version"
+    ],
+    "hooks.internal.load": [
+      "extraDirs"
+    ],
+    "logging": [
+      "consoleLevel",
+      "consoleStyle",
+      "file",
+      "level",
+      "redactPatterns",
+      "redactSensitive"
+    ],
+    "media": [
+      "preserveFilenames"
+    ],
+    "messages": [
+      "ackReaction",
+      "ackReactionScope",
+      "groupChat",
+      "inbound",
+      "messagePrefix",
+      "queue",
+      "removeAckAfterReply",
+      "responsePrefix",
+      "tts"
+    ],
+    "messages.groupChat": [
+      "historyLimit",
+      "mentionPatterns"
+    ],
+    "messages.inbound": [
+      "byChannel",
+      "debounceMs"
+    ],
+    "messages.queue": [
+      "byChannel",
+      "cap",
+      "debounceMs",
+      "debounceMsByChannel",
+      "drop",
+      "mode"
+    ],
+    "messages.queue.byChannel": [
+      "discord",
+      "imessage",
+      "mattermost",
+      "msteams",
+      "signal",
+      "slack",
+      "telegram",
+      "webchat",
+      "whatsapp"
+    ],
+    "messages.tts": [
+      "auto",
+      "edge",
+      "elevenlabs",
+      "enabled",
+      "maxTextLength",
+      "mode",
+      "modelOverrides",
+      "openai",
+      "prefsPath",
+      "provider",
+      "summaryModel",
+      "timeoutMs"
+    ],
+    "messages.tts.edge": [
+      "enabled",
+      "lang",
+      "outputFormat",
+      "pitch",
+      "proxy",
+      "rate",
+      "saveSubtitles",
+      "timeoutMs",
+      "voice",
+      "volume"
+    ],
+    "messages.tts.elevenlabs": [
+      "apiKey",
+      "applyTextNormalization",
+      "baseUrl",
+      "languageCode",
+      "modelId",
+      "seed",
+      "voiceId",
+      "voiceSettings"
+    ],
+    "messages.tts.elevenlabs.voiceSettings": [
+      "similarityBoost",
+      "speed",
+      "stability",
+      "style",
+      "useSpeakerBoost"
+    ],
+    "messages.tts.modelOverrides": [
+      "allowModelId",
+      "allowNormalization",
+      "allowProvider",
+      "allowSeed",
+      "allowText",
+      "allowVoice",
+      "allowVoiceSettings",
+      "enabled"
+    ],
+    "messages.tts.openai": [
+      "apiKey",
+      "model",
+      "voice"
+    ],
+    "meta": [
+      "lastTouchedAt",
+      "lastTouchedVersion"
+    ],
+    "models": [
+      "bedrockDiscovery",
+      "mode",
+      "providers"
+    ],
+    "models.bedrockDiscovery": [
+      "defaultContextWindow",
+      "defaultMaxTokens",
+      "enabled",
+      "providerFilter",
+      "refreshInterval",
+      "region"
+    ],
+    "models.providers.*": [
+      "api",
+      "apiKey",
+      "auth",
+      "authHeader",
+      "baseUrl",
+      "headers",
+      "models"
+    ],
+    "nodeHost": [
+      "browserProxy"
+    ],
+    "nodeHost.browserProxy": [
+      "allowProfiles",
+      "enabled"
+    ],
+    "plugins": [
+      "allow",
+      "deny",
+      "enabled",
+      "entries",
+      "installs",
+      "load",
+      "slots"
+    ],
+    "plugins.entries.*": [
+      "config",
+      "enabled"
+    ],
+    "plugins.installs.*": [
+      "installPath",
+      "installedAt",
+      "source",
+      "sourcePath",
+      "spec",
+      "version"
+    ],
+    "plugins.load": [
+      "paths"
+    ],
+    "plugins.slots": [
+      "memory"
+    ],
+    "session": [
+      "agentToAgent",
+      "dmScope",
+      "identityLinks",
+      "idleMinutes",
+      "mainKey",
+      "reset",
+      "resetByChannel",
+      "resetByType",
+      "resetTriggers",
+      "scope",
+      "sendPolicy",
+      "store",
+      "typingIntervalSeconds",
+      "typingMode"
+    ],
+    "session.agentToAgent": [
+      "maxPingPongTurns"
+    ],
+    "session.reset": [
+      "atHour",
+      "idleMinutes",
+      "mode"
+    ],
+    "session.resetByChannel.*": [
+      "atHour",
+      "idleMinutes",
+      "mode"
+    ],
+    "session.resetByType": [
+      "dm",
+      "group",
+      "thread"
+    ],
+    "session.resetByType.dm": [
+      "atHour",
+      "idleMinutes",
+      "mode"
+    ],
+    "session.resetByType.group": [
+      "atHour",
+      "idleMinutes",
+      "mode"
+    ],
+    "session.resetByType.thread": [
+      "atHour",
+      "idleMinutes",
+      "mode"
+    ],
+    "session.sendPolicy": [
+      "default",
+      "rules"
+    ],
+    "skills": [
+      "allowBundled",
+      "entries",
+      "install",
+      "load"
+    ],
+    "skills.entries.*": [
+      "apiKey",
+      "config",
+      "enabled",
+      "env"
+    ],
+    "skills.install": [
+      "nodeManager",
+      "preferBrew"
+    ],
+    "skills.load": [
+      "extraDirs",
+      "watch",
+      "watchDebounceMs"
+    ],
+    "talk": [
+      "apiKey",
+      "interruptOnSpeech",
+      "modelId",
+      "outputFormat",
+      "voiceAliases",
+      "voiceId"
+    ],
+    "tools": [
+      "agentToAgent",
+      "allow",
+      "alsoAllow",
+      "byProvider",
+      "deny",
+      "elevated",
+      "exec",
+      "links",
+      "media",
+      "message",
+      "profile",
+      "sandbox",
+      "subagents",
+      "web"
+    ],
+    "tools.agentToAgent": [
+      "allow",
+      "enabled"
+    ],
+    "tools.byProvider.*": [
+      "allow",
+      "alsoAllow",
+      "deny",
+      "profile"
+    ],
+    "tools.elevated": [
+      "allowFrom",
+      "enabled"
+    ],
+    "tools.exec": [
+      "applyPatch",
+      "ask",
+      "backgroundMs",
+      "cleanupMs",
+      "host",
+      "node",
+      "notifyOnExit",
+      "pathPrepend",
+      "safeBins",
+      "security",
+      "timeoutSec"
+    ],
+    "tools.exec.applyPatch": [
+      "allowModels",
+      "enabled"
+    ],
+    "tools.links": [
+      "enabled",
+      "maxLinks",
+      "models",
+      "scope",
+      "timeoutSeconds"
+    ],
+    "tools.links.scope": [
+      "default",
+      "rules"
+    ],
+    "tools.media": [
+      "audio",
+      "concurrency",
+      "image",
+      "models",
+      "video"
+    ],
+    "tools.media.audio": [
+      "attachments",
+      "baseUrl",
+      "deepgram",
+      "enabled",
+      "headers",
+      "language",
+      "maxBytes",
+      "maxChars",
+      "models",
+      "prompt",
+      "providerOptions",
+      "scope",
+      "timeoutSeconds"
+    ],
+    "tools.media.audio.attachments": [
+      "maxAttachments",
+      "mode",
+      "prefer"
+    ],
+    "tools.media.audio.deepgram": [
+      "detectLanguage",
+      "punctuate",
+      "smartFormat"
+    ],
+    "tools.media.audio.scope": [
+      "default",
+      "rules"
+    ],
+    "tools.media.image": [
+      "attachments",
+      "baseUrl",
+      "deepgram",
+      "enabled",
+      "headers",
+      "language",
+      "maxBytes",
+      "maxChars",
+      "models",
+      "prompt",
+      "providerOptions",
+      "scope",
+      "timeoutSeconds"
+    ],
+    "tools.media.image.attachments": [
+      "maxAttachments",
+      "mode",
+      "prefer"
+    ],
+    "tools.media.image.deepgram": [
+      "detectLanguage",
+      "punctuate",
+      "smartFormat"
+    ],
+    "tools.media.image.scope": [
+      "default",
+      "rules"
+    ],
+    "tools.media.video": [
+      "attachments",
+      "baseUrl",
+      "deepgram",
+      "enabled",
+      "headers",
+      "language",
+      "maxBytes",
+      "maxChars",
+      "models",
+      "prompt",
+      "providerOptions",
+      "scope",
+      "timeoutSeconds"
+    ],
+    "tools.media.video.attachments": [
+      "maxAttachments",
+      "mode",
+      "prefer"
+    ],
+    "tools.media.video.deepgram": [
+      "detectLanguage",
+      "punctuate",
+      "smartFormat"
+    ],
+    "tools.media.video.scope": [
+      "default",
+      "rules"
+    ],
+    "tools.message": [
+      "allowCrossContextSend",
+      "broadcast",
+      "crossContext"
+    ],
+    "tools.message.broadcast": [
+      "enabled"
+    ],
+    "tools.message.crossContext": [
+      "allowAcrossProviders",
+      "allowWithinProvider",
+      "marker"
+    ],
+    "tools.message.crossContext.marker": [
+      "enabled",
+      "prefix",
+      "suffix"
+    ],
+    "tools.sandbox": [
+      "tools"
+    ],
+    "tools.sandbox.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "tools.subagents": [
+      "tools"
+    ],
+    "tools.subagents.tools": [
+      "allow",
+      "alsoAllow",
+      "deny"
+    ],
+    "tools.web": [
+      "fetch",
+      "search"
+    ],
+    "tools.web.fetch": [
+      "cacheTtlMinutes",
+      "enabled",
+      "maxChars",
+      "maxRedirects",
+      "timeoutSeconds",
+      "userAgent"
+    ],
+    "tools.web.search": [
+      "apiKey",
+      "cacheTtlMinutes",
+      "enabled",
+      "maxResults",
+      "perplexity",
+      "provider",
+      "timeoutSeconds"
+    ],
+    "tools.web.search.perplexity": [
+      "apiKey",
+      "baseUrl",
+      "model"
+    ],
+    "ui": [
+      "assistant",
+      "seamColor"
+    ],
+    "ui.assistant": [
+      "avatar",
+      "name"
+    ],
+    "update": [
+      "channel",
+      "checkOnStart"
+    ],
+    "web": [
+      "enabled",
+      "heartbeatSeconds",
+      "reconnect"
+    ],
+    "web.reconnect": [
+      "factor",
+      "initialMs",
+      "jitter",
+      "maxAttempts",
+      "maxMs"
+    ],
+    "wizard": [
+      "lastRunAt",
+      "lastRunCommand",
+      "lastRunCommit",
+      "lastRunMode",
+      "lastRunVersion"
+    ]
+  },
+  "types": {
+    "agents": {
+      "type": "object"
+    },
+    "agents.defaults": {
+      "type": "object"
+    },
+    "agents.defaults.blockStreamingBreak": {
+      "type": "enum",
+      "values": [
+        "text_end",
+        "message_end"
+      ]
+    },
+    "agents.defaults.blockStreamingChunk": {
+      "type": "object"
+    },
+    "agents.defaults.blockStreamingChunk.breakPreference": {
+      "type": "enum",
+      "values": [
+        "paragraph",
+        "newline",
+        "sentence"
+      ]
+    },
+    "agents.defaults.blockStreamingChunk.maxChars": {
+      "type": "integer"
+    },
+    "agents.defaults.blockStreamingChunk.minChars": {
+      "type": "integer"
+    },
+    "agents.defaults.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "agents.defaults.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "agents.defaults.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "agents.defaults.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "agents.defaults.blockStreamingDefault": {
+      "type": "enum",
+      "values": [
+        "off",
+        "on"
+      ]
+    },
+    "agents.defaults.bootstrapMaxChars": {
+      "type": "integer"
+    },
+    "agents.defaults.cliBackends": {
+      "type": "object"
+    },
+    "agents.defaults.cliBackends.*.args": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.cliBackends.*.clearEnv": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.cliBackends.*.command": {
+      "type": "string"
+    },
+    "agents.defaults.cliBackends.*.env": {
+      "type": "object"
+    },
+    "agents.defaults.cliBackends.*.imageArg": {
+      "type": "string"
+    },
+    "agents.defaults.cliBackends.*.imageMode": {
+      "type": "enum",
+      "values": [
+        "repeat",
+        "list"
+      ]
+    },
+    "agents.defaults.cliBackends.*.input": {
+      "type": "enum",
+      "values": [
+        "arg",
+        "stdin"
+      ]
+    },
+    "agents.defaults.cliBackends.*.maxPromptArgChars": {
+      "type": "integer"
+    },
+    "agents.defaults.cliBackends.*.modelAliases": {
+      "type": "object"
+    },
+    "agents.defaults.cliBackends.*.modelArg": {
+      "type": "string"
+    },
+    "agents.defaults.cliBackends.*.output": {
+      "type": "enum",
+      "values": [
+        "json",
+        "text",
+        "jsonl"
+      ]
+    },
+    "agents.defaults.cliBackends.*.resumeArgs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.cliBackends.*.resumeOutput": {
+      "type": "enum",
+      "values": [
+        "json",
+        "text",
+        "jsonl"
+      ]
+    },
+    "agents.defaults.cliBackends.*.serialize": {
+      "type": "boolean"
+    },
+    "agents.defaults.cliBackends.*.sessionArg": {
+      "type": "string"
+    },
+    "agents.defaults.cliBackends.*.sessionArgs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.cliBackends.*.sessionIdFields": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.cliBackends.*.sessionMode": {
+      "type": "enum",
+      "values": [
+        "always",
+        "existing",
+        "none"
+      ]
+    },
+    "agents.defaults.cliBackends.*.systemPromptArg": {
+      "type": "string"
+    },
+    "agents.defaults.cliBackends.*.systemPromptMode": {
+      "type": "enum",
+      "values": [
+        "append",
+        "replace"
+      ]
+    },
+    "agents.defaults.cliBackends.*.systemPromptWhen": {
+      "type": "enum",
+      "values": [
+        "first",
+        "always",
+        "never"
+      ]
+    },
+    "agents.defaults.compaction": {
+      "type": "object"
+    },
+    "agents.defaults.compaction.maxHistoryShare": {
+      "type": "number"
+    },
+    "agents.defaults.compaction.memoryFlush": {
+      "type": "object"
+    },
+    "agents.defaults.compaction.memoryFlush.enabled": {
+      "type": "boolean"
+    },
+    "agents.defaults.compaction.memoryFlush.prompt": {
+      "type": "string"
+    },
+    "agents.defaults.compaction.memoryFlush.softThresholdTokens": {
+      "type": "integer"
+    },
+    "agents.defaults.compaction.memoryFlush.systemPrompt": {
+      "type": "string"
+    },
+    "agents.defaults.compaction.mode": {
+      "type": "enum",
+      "values": [
+        "default",
+        "safeguard"
+      ]
+    },
+    "agents.defaults.compaction.reserveTokensFloor": {
+      "type": "integer"
+    },
+    "agents.defaults.contextPruning": {
+      "type": "object"
+    },
+    "agents.defaults.contextPruning.hardClear": {
+      "type": "object"
+    },
+    "agents.defaults.contextPruning.hardClear.enabled": {
+      "type": "boolean"
+    },
+    "agents.defaults.contextPruning.hardClear.placeholder": {
+      "type": "string"
+    },
+    "agents.defaults.contextPruning.hardClearRatio": {
+      "type": "number"
+    },
+    "agents.defaults.contextPruning.keepLastAssistants": {
+      "type": "integer"
+    },
+    "agents.defaults.contextPruning.minPrunableToolChars": {
+      "type": "integer"
+    },
+    "agents.defaults.contextPruning.mode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "cache-ttl"
+      ]
+    },
+    "agents.defaults.contextPruning.softTrim": {
+      "type": "object"
+    },
+    "agents.defaults.contextPruning.softTrim.headChars": {
+      "type": "integer"
+    },
+    "agents.defaults.contextPruning.softTrim.maxChars": {
+      "type": "integer"
+    },
+    "agents.defaults.contextPruning.softTrim.tailChars": {
+      "type": "integer"
+    },
+    "agents.defaults.contextPruning.softTrimRatio": {
+      "type": "number"
+    },
+    "agents.defaults.contextPruning.tools": {
+      "type": "object"
+    },
+    "agents.defaults.contextPruning.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.contextPruning.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.contextPruning.ttl": {
+      "type": "string"
+    },
+    "agents.defaults.contextTokens": {
+      "type": "integer"
+    },
+    "agents.defaults.elevatedDefault": {
+      "type": "enum",
+      "values": [
+        "off",
+        "on",
+        "ask",
+        "full"
+      ]
+    },
+    "agents.defaults.envelopeElapsed": {
+      "type": "enum",
+      "values": [
+        "on",
+        "off"
+      ]
+    },
+    "agents.defaults.envelopeTimestamp": {
+      "type": "enum",
+      "values": [
+        "on",
+        "off"
+      ]
+    },
+    "agents.defaults.envelopeTimezone": {
+      "type": "string"
+    },
+    "agents.defaults.heartbeat": {
+      "type": "object"
+    },
+    "agents.defaults.heartbeat.ackMaxChars": {
+      "type": "integer"
+    },
+    "agents.defaults.heartbeat.activeHours": {
+      "type": "object"
+    },
+    "agents.defaults.heartbeat.activeHours.end": {
+      "type": "string"
+    },
+    "agents.defaults.heartbeat.activeHours.start": {
+      "type": "string"
+    },
+    "agents.defaults.heartbeat.activeHours.timezone": {
+      "type": "string"
+    },
+    "agents.defaults.heartbeat.every": {
+      "type": "string"
+    },
+    "agents.defaults.heartbeat.includeReasoning": {
+      "type": "boolean"
+    },
+    "agents.defaults.heartbeat.model": {
+      "type": "string"
+    },
+    "agents.defaults.heartbeat.prompt": {
+      "type": "string"
+    },
+    "agents.defaults.heartbeat.session": {
+      "type": "string"
+    },
+    "agents.defaults.heartbeat.target": {
+      "type": "string"
+    },
+    "agents.defaults.heartbeat.to": {
+      "type": "string"
+    },
+    "agents.defaults.humanDelay": {
+      "type": "object"
+    },
+    "agents.defaults.humanDelay.maxMs": {
+      "type": "integer"
+    },
+    "agents.defaults.humanDelay.minMs": {
+      "type": "integer"
+    },
+    "agents.defaults.humanDelay.mode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "natural",
+        "custom"
+      ]
+    },
+    "agents.defaults.imageModel": {
+      "type": "object"
+    },
+    "agents.defaults.imageModel.fallbacks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.imageModel.primary": {
+      "type": "string"
+    },
+    "agents.defaults.maxConcurrent": {
+      "type": "integer"
+    },
+    "agents.defaults.mediaMaxMb": {
+      "type": "number"
+    },
+    "agents.defaults.memorySearch": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.cache": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.cache.enabled": {
+      "type": "boolean"
+    },
+    "agents.defaults.memorySearch.cache.maxEntries": {
+      "type": "integer"
+    },
+    "agents.defaults.memorySearch.chunking": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.chunking.overlap": {
+      "type": "integer"
+    },
+    "agents.defaults.memorySearch.chunking.tokens": {
+      "type": "integer"
+    },
+    "agents.defaults.memorySearch.enabled": {
+      "type": "boolean"
+    },
+    "agents.defaults.memorySearch.experimental": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.experimental.sessionMemory": {
+      "type": "boolean"
+    },
+    "agents.defaults.memorySearch.extraPaths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.memorySearch.fallback": {
+      "type": "enum",
+      "values": [
+        "openai",
+        "gemini",
+        "local",
+        "none"
+      ]
+    },
+    "agents.defaults.memorySearch.local": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.local.modelCacheDir": {
+      "type": "string"
+    },
+    "agents.defaults.memorySearch.local.modelPath": {
+      "type": "string"
+    },
+    "agents.defaults.memorySearch.model": {
+      "type": "string"
+    },
+    "agents.defaults.memorySearch.provider": {
+      "type": "enum",
+      "values": [
+        "openai",
+        "local",
+        "gemini"
+      ]
+    },
+    "agents.defaults.memorySearch.query": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.query.hybrid": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.query.hybrid.candidateMultiplier": {
+      "type": "integer"
+    },
+    "agents.defaults.memorySearch.query.hybrid.enabled": {
+      "type": "boolean"
+    },
+    "agents.defaults.memorySearch.query.hybrid.textWeight": {
+      "type": "number"
+    },
+    "agents.defaults.memorySearch.query.hybrid.vectorWeight": {
+      "type": "number"
+    },
+    "agents.defaults.memorySearch.query.maxResults": {
+      "type": "integer"
+    },
+    "agents.defaults.memorySearch.query.minScore": {
+      "type": "number"
+    },
+    "agents.defaults.memorySearch.remote": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.remote.apiKey": {
+      "type": "string"
+    },
+    "agents.defaults.memorySearch.remote.baseUrl": {
+      "type": "string"
+    },
+    "agents.defaults.memorySearch.remote.batch": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.remote.batch.concurrency": {
+      "type": "integer"
+    },
+    "agents.defaults.memorySearch.remote.batch.enabled": {
+      "type": "boolean"
+    },
+    "agents.defaults.memorySearch.remote.batch.pollIntervalMs": {
+      "type": "integer"
+    },
+    "agents.defaults.memorySearch.remote.batch.timeoutMinutes": {
+      "type": "integer"
+    },
+    "agents.defaults.memorySearch.remote.batch.wait": {
+      "type": "boolean"
+    },
+    "agents.defaults.memorySearch.remote.headers": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.sources": {
+      "type": "array",
+      "items": {
+        "type": "enum",
+        "values": [
+          "memory",
+          "sessions"
+        ]
+      }
+    },
+    "agents.defaults.memorySearch.store": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.store.driver": {
+      "type": "enum",
+      "values": [
+        "sqlite"
+      ]
+    },
+    "agents.defaults.memorySearch.store.path": {
+      "type": "string"
+    },
+    "agents.defaults.memorySearch.store.vector": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.store.vector.enabled": {
+      "type": "boolean"
+    },
+    "agents.defaults.memorySearch.store.vector.extensionPath": {
+      "type": "string"
+    },
+    "agents.defaults.memorySearch.sync": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.sync.intervalMinutes": {
+      "type": "integer"
+    },
+    "agents.defaults.memorySearch.sync.onSearch": {
+      "type": "boolean"
+    },
+    "agents.defaults.memorySearch.sync.onSessionStart": {
+      "type": "boolean"
+    },
+    "agents.defaults.memorySearch.sync.sessions": {
+      "type": "object"
+    },
+    "agents.defaults.memorySearch.sync.sessions.deltaBytes": {
+      "type": "integer"
+    },
+    "agents.defaults.memorySearch.sync.sessions.deltaMessages": {
+      "type": "integer"
+    },
+    "agents.defaults.memorySearch.sync.watch": {
+      "type": "boolean"
+    },
+    "agents.defaults.memorySearch.sync.watchDebounceMs": {
+      "type": "integer"
+    },
+    "agents.defaults.model": {
+      "type": "object"
+    },
+    "agents.defaults.model.fallbacks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.model.primary": {
+      "type": "string"
+    },
+    "agents.defaults.models": {
+      "type": "object"
+    },
+    "agents.defaults.models.*.alias": {
+      "type": "string"
+    },
+    "agents.defaults.models.*.params": {
+      "type": "object"
+    },
+    "agents.defaults.repoRoot": {
+      "type": "string"
+    },
+    "agents.defaults.sandbox": {
+      "type": "object"
+    },
+    "agents.defaults.sandbox.browser": {
+      "type": "object"
+    },
+    "agents.defaults.sandbox.browser.allowHostControl": {
+      "type": "boolean"
+    },
+    "agents.defaults.sandbox.browser.autoStart": {
+      "type": "boolean"
+    },
+    "agents.defaults.sandbox.browser.autoStartTimeoutMs": {
+      "type": "integer"
+    },
+    "agents.defaults.sandbox.browser.cdpPort": {
+      "type": "integer"
+    },
+    "agents.defaults.sandbox.browser.containerPrefix": {
+      "type": "string"
+    },
+    "agents.defaults.sandbox.browser.enableNoVnc": {
+      "type": "boolean"
+    },
+    "agents.defaults.sandbox.browser.enabled": {
+      "type": "boolean"
+    },
+    "agents.defaults.sandbox.browser.headless": {
+      "type": "boolean"
+    },
+    "agents.defaults.sandbox.browser.image": {
+      "type": "string"
+    },
+    "agents.defaults.sandbox.browser.noVncPort": {
+      "type": "integer"
+    },
+    "agents.defaults.sandbox.browser.vncPort": {
+      "type": "integer"
+    },
+    "agents.defaults.sandbox.docker": {
+      "type": "object"
+    },
+    "agents.defaults.sandbox.docker.apparmorProfile": {
+      "type": "string"
+    },
+    "agents.defaults.sandbox.docker.binds": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.sandbox.docker.capDrop": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.sandbox.docker.containerPrefix": {
+      "type": "string"
+    },
+    "agents.defaults.sandbox.docker.cpus": {
+      "type": "number"
+    },
+    "agents.defaults.sandbox.docker.dns": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.sandbox.docker.env": {
+      "type": "object"
+    },
+    "agents.defaults.sandbox.docker.extraHosts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.sandbox.docker.image": {
+      "type": "string"
+    },
+    "agents.defaults.sandbox.docker.memory": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "agents.defaults.sandbox.docker.memorySwap": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "agents.defaults.sandbox.docker.network": {
+      "type": "string"
+    },
+    "agents.defaults.sandbox.docker.pidsLimit": {
+      "type": "integer"
+    },
+    "agents.defaults.sandbox.docker.readOnlyRoot": {
+      "type": "boolean"
+    },
+    "agents.defaults.sandbox.docker.seccompProfile": {
+      "type": "string"
+    },
+    "agents.defaults.sandbox.docker.setupCommand": {
+      "type": "string"
+    },
+    "agents.defaults.sandbox.docker.tmpfs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents.defaults.sandbox.docker.ulimits": {
+      "type": "object"
+    },
+    "agents.defaults.sandbox.docker.user": {
+      "type": "string"
+    },
+    "agents.defaults.sandbox.docker.workdir": {
+      "type": "string"
+    },
+    "agents.defaults.sandbox.mode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "non-main",
+        "all"
+      ]
+    },
+    "agents.defaults.sandbox.perSession": {
+      "type": "boolean"
+    },
+    "agents.defaults.sandbox.prune": {
+      "type": "object"
+    },
+    "agents.defaults.sandbox.prune.idleHours": {
+      "type": "integer"
+    },
+    "agents.defaults.sandbox.prune.maxAgeDays": {
+      "type": "integer"
+    },
+    "agents.defaults.sandbox.scope": {
+      "type": "enum",
+      "values": [
+        "session",
+        "agent",
+        "shared"
+      ]
+    },
+    "agents.defaults.sandbox.sessionToolsVisibility": {
+      "type": "enum",
+      "values": [
+        "spawned",
+        "all"
+      ]
+    },
+    "agents.defaults.sandbox.workspaceAccess": {
+      "type": "enum",
+      "values": [
+        "none",
+        "ro",
+        "rw"
+      ]
+    },
+    "agents.defaults.sandbox.workspaceRoot": {
+      "type": "string"
+    },
+    "agents.defaults.skipBootstrap": {
+      "type": "boolean"
+    },
+    "agents.defaults.subagents": {
+      "type": "object"
+    },
+    "agents.defaults.subagents.archiveAfterMinutes": {
+      "type": "integer"
+    },
+    "agents.defaults.subagents.maxConcurrent": {
+      "type": "integer"
+    },
+    "agents.defaults.subagents.model": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "agents.defaults.thinkingDefault": {
+      "type": "enum",
+      "values": [
+        "off",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ]
+    },
+    "agents.defaults.timeFormat": {
+      "type": "enum",
+      "values": [
+        "auto",
+        "12",
+        "24"
+      ]
+    },
+    "agents.defaults.timeoutSeconds": {
+      "type": "integer"
+    },
+    "agents.defaults.typingIntervalSeconds": {
+      "type": "integer"
+    },
+    "agents.defaults.typingMode": {
+      "type": "enum",
+      "values": [
+        "never",
+        "instant",
+        "thinking",
+        "message"
+      ]
+    },
+    "agents.defaults.userTimezone": {
+      "type": "string"
+    },
+    "agents.defaults.verboseDefault": {
+      "type": "enum",
+      "values": [
+        "off",
+        "on",
+        "full"
+      ]
+    },
+    "agents.defaults.workspace": {
+      "type": "string"
+    },
+    "agents.list": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "approvals": {
+      "type": "object"
+    },
+    "approvals.exec": {
+      "type": "object"
+    },
+    "approvals.exec.agentFilter": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "approvals.exec.enabled": {
+      "type": "boolean"
+    },
+    "approvals.exec.mode": {
+      "type": "enum",
+      "values": [
+        "session",
+        "targets",
+        "both"
+      ]
+    },
+    "approvals.exec.sessionFilter": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "approvals.exec.targets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "audio": {
+      "type": "object"
+    },
+    "audio.transcription": {
+      "type": "object"
+    },
+    "audio.transcription.command": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "audio.transcription.timeoutSeconds": {
+      "type": "integer"
+    },
+    "auth": {
+      "type": "object"
+    },
+    "auth.cooldowns": {
+      "type": "object"
+    },
+    "auth.cooldowns.billingBackoffHours": {
+      "type": "number"
+    },
+    "auth.cooldowns.billingBackoffHoursByProvider": {
+      "type": "object"
+    },
+    "auth.cooldowns.billingMaxHours": {
+      "type": "number"
+    },
+    "auth.cooldowns.failureWindowHours": {
+      "type": "number"
+    },
+    "auth.order": {
+      "type": "object"
+    },
+    "auth.profiles": {
+      "type": "object"
+    },
+    "auth.profiles.*.email": {
+      "type": "string"
+    },
+    "auth.profiles.*.mode": {
+      "type": "enum",
+      "values": [
+        "api_key",
+        "oauth",
+        "token"
+      ]
+    },
+    "auth.profiles.*.provider": {
+      "type": "string"
+    },
+    "bindings": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "broadcast": {
+      "type": "object"
+    },
+    "broadcast.strategy": {
+      "type": "enum",
+      "values": [
+        "parallel",
+        "sequential"
+      ]
+    },
+    "browser": {
+      "type": "object"
+    },
+    "browser.attachOnly": {
+      "type": "boolean"
+    },
+    "browser.cdpUrl": {
+      "type": "string"
+    },
+    "browser.color": {
+      "type": "string"
+    },
+    "browser.defaultProfile": {
+      "type": "string"
+    },
+    "browser.enabled": {
+      "type": "boolean"
+    },
+    "browser.evaluateEnabled": {
+      "type": "boolean"
+    },
+    "browser.executablePath": {
+      "type": "string"
+    },
+    "browser.headless": {
+      "type": "boolean"
+    },
+    "browser.noSandbox": {
+      "type": "boolean"
+    },
+    "browser.profiles": {
+      "type": "object"
+    },
+    "browser.profiles.*.cdpPort": {
+      "type": "integer"
+    },
+    "browser.profiles.*.cdpUrl": {
+      "type": "string"
+    },
+    "browser.profiles.*.color": {
+      "type": "string"
+    },
+    "browser.profiles.*.driver": {
+      "type": "enum",
+      "values": [
+        "openclaw",
+        "extension"
+      ]
+    },
+    "browser.remoteCdpHandshakeTimeoutMs": {
+      "type": "integer"
+    },
+    "browser.remoteCdpTimeoutMs": {
+      "type": "integer"
+    },
+    "browser.snapshotDefaults": {
+      "type": "object"
+    },
+    "browser.snapshotDefaults.mode": {
+      "type": "enum",
+      "values": [
+        "efficient"
+      ]
+    },
+    "canvasHost": {
+      "type": "object"
+    },
+    "canvasHost.enabled": {
+      "type": "boolean"
+    },
+    "canvasHost.liveReload": {
+      "type": "boolean"
+    },
+    "canvasHost.port": {
+      "type": "integer"
+    },
+    "canvasHost.root": {
+      "type": "string"
+    },
+    "channels": {
+      "type": "object"
+    },
+    "channels.bluebubbles": {
+      "type": "object"
+    },
+    "channels.bluebubbles.accounts": {
+      "type": "object"
+    },
+    "channels.bluebubbles.accounts.*.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.bluebubbles.accounts.*.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.accounts.*.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.bluebubbles.accounts.*.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.accounts.*.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.accounts.*.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.accounts.*.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.accounts.*.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.bluebubbles.accounts.*.configWrites": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.accounts.*.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.accounts.*.dmPolicy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.bluebubbles.accounts.*.dms": {
+      "type": "object"
+    },
+    "channels.bluebubbles.accounts.*.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.accounts.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.accounts.*.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.bluebubbles.accounts.*.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.bluebubbles.accounts.*.groups": {
+      "type": "object"
+    },
+    "channels.bluebubbles.accounts.*.groups.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.accounts.*.groups.*.tools": {
+      "type": "object"
+    },
+    "channels.bluebubbles.accounts.*.groups.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.accounts.*.groups.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.accounts.*.groups.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.accounts.*.groups.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.bluebubbles.accounts.*.groups.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.accounts.*.groups.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.accounts.*.groups.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.accounts.*.heartbeat": {
+      "type": "object"
+    },
+    "channels.bluebubbles.accounts.*.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.accounts.*.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.accounts.*.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.accounts.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.accounts.*.markdown": {
+      "type": "object"
+    },
+    "channels.bluebubbles.accounts.*.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.bluebubbles.accounts.*.mediaMaxMb": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.accounts.*.name": {
+      "type": "string"
+    },
+    "channels.bluebubbles.accounts.*.password": {
+      "type": "string"
+    },
+    "channels.bluebubbles.accounts.*.sendReadReceipts": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.accounts.*.serverUrl": {
+      "type": "string"
+    },
+    "channels.bluebubbles.accounts.*.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.accounts.*.webhookPath": {
+      "type": "string"
+    },
+    "channels.bluebubbles.actions": {
+      "type": "object"
+    },
+    "channels.bluebubbles.actions.addParticipant": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.actions.edit": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.actions.leaveGroup": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.actions.reactions": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.actions.removeParticipant": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.actions.renameGroup": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.actions.reply": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.actions.sendAttachment": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.actions.sendWithEffect": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.actions.setGroupIcon": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.actions.unsend": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.bluebubbles.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.bluebubbles.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.bluebubbles.configWrites": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.dmPolicy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.bluebubbles.dms": {
+      "type": "object"
+    },
+    "channels.bluebubbles.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.enabled": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.bluebubbles.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.bluebubbles.groups": {
+      "type": "object"
+    },
+    "channels.bluebubbles.groups.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.groups.*.tools": {
+      "type": "object"
+    },
+    "channels.bluebubbles.groups.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.groups.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.groups.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.groups.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.bluebubbles.groups.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.groups.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.groups.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.bluebubbles.heartbeat": {
+      "type": "object"
+    },
+    "channels.bluebubbles.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.historyLimit": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.markdown": {
+      "type": "object"
+    },
+    "channels.bluebubbles.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.bluebubbles.mediaMaxMb": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.name": {
+      "type": "string"
+    },
+    "channels.bluebubbles.password": {
+      "type": "string"
+    },
+    "channels.bluebubbles.sendReadReceipts": {
+      "type": "boolean"
+    },
+    "channels.bluebubbles.serverUrl": {
+      "type": "string"
+    },
+    "channels.bluebubbles.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.bluebubbles.webhookPath": {
+      "type": "string"
+    },
+    "channels.defaults": {
+      "type": "object"
+    },
+    "channels.defaults.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.defaults.heartbeat": {
+      "type": "object"
+    },
+    "channels.defaults.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.defaults.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.defaults.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.discord": {
+      "type": "object"
+    },
+    "channels.discord.accounts": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.actions": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.actions.channelInfo": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.channels": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.emojiUploads": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.events": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.memberInfo": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.messages": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.moderation": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.permissions": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.pins": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.polls": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.reactions": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.roleInfo": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.roles": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.search": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.stickerUploads": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.stickers": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.threads": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.actions.voiceStatus": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.allowBots": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.discord.accounts.*.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.discord.accounts.*.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.discord.accounts.*.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.discord.accounts.*.commands": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.commands.native": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "channels.discord.accounts.*.commands.nativeSkills": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "channels.discord.accounts.*.configWrites": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.dm": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.dm.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.discord.accounts.*.dm.enabled": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.dm.groupChannels": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.discord.accounts.*.dm.groupEnabled": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.dm.policy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.discord.accounts.*.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.discord.accounts.*.dms": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.discord.accounts.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.execApprovals": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.execApprovals.agentFilter": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.execApprovals.approvers": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.discord.accounts.*.execApprovals.enabled": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.execApprovals.sessionFilter": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.discord.accounts.*.guilds": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.guilds.*.channels": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.allow": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.autoThread": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.skills": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.systemPrompt": {
+      "type": "string"
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.tools": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.channels.*.users": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.reactionNotifications": {
+      "type": "enum",
+      "values": [
+        "off",
+        "own",
+        "all",
+        "allowlist"
+      ]
+    },
+    "channels.discord.accounts.*.guilds.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.guilds.*.slug": {
+      "type": "string"
+    },
+    "channels.discord.accounts.*.guilds.*.tools": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.guilds.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.guilds.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.accounts.*.guilds.*.users": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.discord.accounts.*.heartbeat": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.discord.accounts.*.intents": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.intents.guildMembers": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.intents.presence": {
+      "type": "boolean"
+    },
+    "channels.discord.accounts.*.markdown": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.discord.accounts.*.maxLinesPerMessage": {
+      "type": "integer"
+    },
+    "channels.discord.accounts.*.mediaMaxMb": {
+      "type": "number"
+    },
+    "channels.discord.accounts.*.name": {
+      "type": "string"
+    },
+    "channels.discord.accounts.*.replyToMode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.discord.accounts.*.retry": {
+      "type": "object"
+    },
+    "channels.discord.accounts.*.retry.attempts": {
+      "type": "integer"
+    },
+    "channels.discord.accounts.*.retry.jitter": {
+      "type": "number"
+    },
+    "channels.discord.accounts.*.retry.maxDelayMs": {
+      "type": "integer"
+    },
+    "channels.discord.accounts.*.retry.minDelayMs": {
+      "type": "integer"
+    },
+    "channels.discord.accounts.*.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.discord.accounts.*.token": {
+      "type": "string"
+    },
+    "channels.discord.actions": {
+      "type": "object"
+    },
+    "channels.discord.actions.channelInfo": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.channels": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.emojiUploads": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.events": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.memberInfo": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.messages": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.moderation": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.permissions": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.pins": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.polls": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.reactions": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.roleInfo": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.roles": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.search": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.stickerUploads": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.stickers": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.threads": {
+      "type": "boolean"
+    },
+    "channels.discord.actions.voiceStatus": {
+      "type": "boolean"
+    },
+    "channels.discord.allowBots": {
+      "type": "boolean"
+    },
+    "channels.discord.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.discord.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.discord.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.discord.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.discord.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.discord.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.discord.commands": {
+      "type": "object"
+    },
+    "channels.discord.commands.native": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "channels.discord.commands.nativeSkills": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "channels.discord.configWrites": {
+      "type": "boolean"
+    },
+    "channels.discord.dm": {
+      "type": "object"
+    },
+    "channels.discord.dm.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.discord.dm.enabled": {
+      "type": "boolean"
+    },
+    "channels.discord.dm.groupChannels": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.discord.dm.groupEnabled": {
+      "type": "boolean"
+    },
+    "channels.discord.dm.policy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.discord.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.discord.dms": {
+      "type": "object"
+    },
+    "channels.discord.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.discord.enabled": {
+      "type": "boolean"
+    },
+    "channels.discord.execApprovals": {
+      "type": "object"
+    },
+    "channels.discord.execApprovals.agentFilter": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.execApprovals.approvers": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.discord.execApprovals.enabled": {
+      "type": "boolean"
+    },
+    "channels.discord.execApprovals.sessionFilter": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.discord.guilds": {
+      "type": "object"
+    },
+    "channels.discord.guilds.*.channels": {
+      "type": "object"
+    },
+    "channels.discord.guilds.*.channels.*.allow": {
+      "type": "boolean"
+    },
+    "channels.discord.guilds.*.channels.*.autoThread": {
+      "type": "boolean"
+    },
+    "channels.discord.guilds.*.channels.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.discord.guilds.*.channels.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.discord.guilds.*.channels.*.skills": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.channels.*.systemPrompt": {
+      "type": "string"
+    },
+    "channels.discord.guilds.*.channels.*.tools": {
+      "type": "object"
+    },
+    "channels.discord.guilds.*.channels.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.channels.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.channels.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.channels.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.discord.guilds.*.channels.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.channels.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.channels.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.channels.*.users": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.discord.guilds.*.reactionNotifications": {
+      "type": "enum",
+      "values": [
+        "off",
+        "own",
+        "all",
+        "allowlist"
+      ]
+    },
+    "channels.discord.guilds.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.discord.guilds.*.slug": {
+      "type": "string"
+    },
+    "channels.discord.guilds.*.tools": {
+      "type": "object"
+    },
+    "channels.discord.guilds.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.discord.guilds.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.discord.guilds.*.users": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.discord.heartbeat": {
+      "type": "object"
+    },
+    "channels.discord.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.discord.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.discord.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.discord.historyLimit": {
+      "type": "integer"
+    },
+    "channels.discord.intents": {
+      "type": "object"
+    },
+    "channels.discord.intents.guildMembers": {
+      "type": "boolean"
+    },
+    "channels.discord.intents.presence": {
+      "type": "boolean"
+    },
+    "channels.discord.markdown": {
+      "type": "object"
+    },
+    "channels.discord.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.discord.maxLinesPerMessage": {
+      "type": "integer"
+    },
+    "channels.discord.mediaMaxMb": {
+      "type": "number"
+    },
+    "channels.discord.name": {
+      "type": "string"
+    },
+    "channels.discord.replyToMode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.discord.retry": {
+      "type": "object"
+    },
+    "channels.discord.retry.attempts": {
+      "type": "integer"
+    },
+    "channels.discord.retry.jitter": {
+      "type": "number"
+    },
+    "channels.discord.retry.maxDelayMs": {
+      "type": "integer"
+    },
+    "channels.discord.retry.minDelayMs": {
+      "type": "integer"
+    },
+    "channels.discord.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.discord.token": {
+      "type": "string"
+    },
+    "channels.googlechat": {
+      "type": "object"
+    },
+    "channels.googlechat.accounts": {
+      "type": "object"
+    },
+    "channels.googlechat.accounts.*.actions": {
+      "type": "object"
+    },
+    "channels.googlechat.accounts.*.actions.reactions": {
+      "type": "boolean"
+    },
+    "channels.googlechat.accounts.*.allowBots": {
+      "type": "boolean"
+    },
+    "channels.googlechat.accounts.*.audience": {
+      "type": "string"
+    },
+    "channels.googlechat.accounts.*.audienceType": {
+      "type": "enum",
+      "values": [
+        "app-url",
+        "project-number"
+      ]
+    },
+    "channels.googlechat.accounts.*.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.googlechat.accounts.*.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.googlechat.accounts.*.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.googlechat.accounts.*.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.googlechat.accounts.*.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.googlechat.accounts.*.botUser": {
+      "type": "string"
+    },
+    "channels.googlechat.accounts.*.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.googlechat.accounts.*.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.googlechat.accounts.*.configWrites": {
+      "type": "boolean"
+    },
+    "channels.googlechat.accounts.*.dm": {
+      "type": "object"
+    },
+    "channels.googlechat.accounts.*.dm.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.googlechat.accounts.*.dm.enabled": {
+      "type": "boolean"
+    },
+    "channels.googlechat.accounts.*.dm.policy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.googlechat.accounts.*.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.googlechat.accounts.*.dms": {
+      "type": "object"
+    },
+    "channels.googlechat.accounts.*.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.googlechat.accounts.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.googlechat.accounts.*.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.googlechat.accounts.*.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.googlechat.accounts.*.groups": {
+      "type": "object"
+    },
+    "channels.googlechat.accounts.*.groups.*.allow": {
+      "type": "boolean"
+    },
+    "channels.googlechat.accounts.*.groups.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.googlechat.accounts.*.groups.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.googlechat.accounts.*.groups.*.systemPrompt": {
+      "type": "string"
+    },
+    "channels.googlechat.accounts.*.groups.*.users": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.googlechat.accounts.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.googlechat.accounts.*.mediaMaxMb": {
+      "type": "number"
+    },
+    "channels.googlechat.accounts.*.name": {
+      "type": "string"
+    },
+    "channels.googlechat.accounts.*.replyToMode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.googlechat.accounts.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.googlechat.accounts.*.serviceAccount": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "channels.googlechat.accounts.*.serviceAccountFile": {
+      "type": "string"
+    },
+    "channels.googlechat.accounts.*.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.googlechat.accounts.*.typingIndicator": {
+      "type": "enum",
+      "values": [
+        "none",
+        "message",
+        "reaction"
+      ]
+    },
+    "channels.googlechat.accounts.*.webhookPath": {
+      "type": "string"
+    },
+    "channels.googlechat.accounts.*.webhookUrl": {
+      "type": "string"
+    },
+    "channels.googlechat.actions": {
+      "type": "object"
+    },
+    "channels.googlechat.actions.reactions": {
+      "type": "boolean"
+    },
+    "channels.googlechat.allowBots": {
+      "type": "boolean"
+    },
+    "channels.googlechat.audience": {
+      "type": "string"
+    },
+    "channels.googlechat.audienceType": {
+      "type": "enum",
+      "values": [
+        "app-url",
+        "project-number"
+      ]
+    },
+    "channels.googlechat.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.googlechat.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.googlechat.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.googlechat.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.googlechat.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.googlechat.botUser": {
+      "type": "string"
+    },
+    "channels.googlechat.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.googlechat.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.googlechat.configWrites": {
+      "type": "boolean"
+    },
+    "channels.googlechat.defaultAccount": {
+      "type": "string"
+    },
+    "channels.googlechat.dm": {
+      "type": "object"
+    },
+    "channels.googlechat.dm.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.googlechat.dm.enabled": {
+      "type": "boolean"
+    },
+    "channels.googlechat.dm.policy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.googlechat.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.googlechat.dms": {
+      "type": "object"
+    },
+    "channels.googlechat.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.googlechat.enabled": {
+      "type": "boolean"
+    },
+    "channels.googlechat.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.googlechat.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.googlechat.groups": {
+      "type": "object"
+    },
+    "channels.googlechat.groups.*.allow": {
+      "type": "boolean"
+    },
+    "channels.googlechat.groups.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.googlechat.groups.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.googlechat.groups.*.systemPrompt": {
+      "type": "string"
+    },
+    "channels.googlechat.groups.*.users": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.googlechat.historyLimit": {
+      "type": "integer"
+    },
+    "channels.googlechat.mediaMaxMb": {
+      "type": "number"
+    },
+    "channels.googlechat.name": {
+      "type": "string"
+    },
+    "channels.googlechat.replyToMode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.googlechat.requireMention": {
+      "type": "boolean"
+    },
+    "channels.googlechat.serviceAccount": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "channels.googlechat.serviceAccountFile": {
+      "type": "string"
+    },
+    "channels.googlechat.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.googlechat.typingIndicator": {
+      "type": "enum",
+      "values": [
+        "none",
+        "message",
+        "reaction"
+      ]
+    },
+    "channels.googlechat.webhookPath": {
+      "type": "string"
+    },
+    "channels.googlechat.webhookUrl": {
+      "type": "string"
+    },
+    "channels.imessage": {
+      "type": "object"
+    },
+    "channels.imessage.accounts": {
+      "type": "object"
+    },
+    "channels.imessage.accounts.*.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.imessage.accounts.*.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.imessage.accounts.*.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.imessage.accounts.*.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.imessage.accounts.*.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.imessage.accounts.*.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.imessage.accounts.*.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.accounts.*.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.imessage.accounts.*.cliPath": {
+      "type": "string"
+    },
+    "channels.imessage.accounts.*.configWrites": {
+      "type": "boolean"
+    },
+    "channels.imessage.accounts.*.dbPath": {
+      "type": "string"
+    },
+    "channels.imessage.accounts.*.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.imessage.accounts.*.dmPolicy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.imessage.accounts.*.dms": {
+      "type": "object"
+    },
+    "channels.imessage.accounts.*.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.imessage.accounts.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.imessage.accounts.*.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.imessage.accounts.*.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.imessage.accounts.*.groups": {
+      "type": "object"
+    },
+    "channels.imessage.accounts.*.groups.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.imessage.accounts.*.groups.*.tools": {
+      "type": "object"
+    },
+    "channels.imessage.accounts.*.groups.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.accounts.*.groups.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.accounts.*.groups.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.accounts.*.groups.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.imessage.accounts.*.groups.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.accounts.*.groups.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.accounts.*.groups.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.accounts.*.heartbeat": {
+      "type": "object"
+    },
+    "channels.imessage.accounts.*.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.imessage.accounts.*.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.imessage.accounts.*.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.imessage.accounts.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.imessage.accounts.*.includeAttachments": {
+      "type": "boolean"
+    },
+    "channels.imessage.accounts.*.markdown": {
+      "type": "object"
+    },
+    "channels.imessage.accounts.*.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.imessage.accounts.*.mediaMaxMb": {
+      "type": "integer"
+    },
+    "channels.imessage.accounts.*.name": {
+      "type": "string"
+    },
+    "channels.imessage.accounts.*.region": {
+      "type": "string"
+    },
+    "channels.imessage.accounts.*.remoteHost": {
+      "type": "string"
+    },
+    "channels.imessage.accounts.*.service": {
+      "type": "enum",
+      "values": [
+        "imessage",
+        "sms",
+        "auto"
+      ]
+    },
+    "channels.imessage.accounts.*.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.imessage.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.imessage.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.imessage.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.imessage.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.imessage.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.imessage.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.imessage.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.imessage.cliPath": {
+      "type": "string"
+    },
+    "channels.imessage.configWrites": {
+      "type": "boolean"
+    },
+    "channels.imessage.dbPath": {
+      "type": "string"
+    },
+    "channels.imessage.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.imessage.dmPolicy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.imessage.dms": {
+      "type": "object"
+    },
+    "channels.imessage.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.imessage.enabled": {
+      "type": "boolean"
+    },
+    "channels.imessage.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.imessage.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.imessage.groups": {
+      "type": "object"
+    },
+    "channels.imessage.groups.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.imessage.groups.*.tools": {
+      "type": "object"
+    },
+    "channels.imessage.groups.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.groups.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.groups.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.groups.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.imessage.groups.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.groups.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.groups.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.imessage.heartbeat": {
+      "type": "object"
+    },
+    "channels.imessage.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.imessage.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.imessage.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.imessage.historyLimit": {
+      "type": "integer"
+    },
+    "channels.imessage.includeAttachments": {
+      "type": "boolean"
+    },
+    "channels.imessage.markdown": {
+      "type": "object"
+    },
+    "channels.imessage.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.imessage.mediaMaxMb": {
+      "type": "integer"
+    },
+    "channels.imessage.name": {
+      "type": "string"
+    },
+    "channels.imessage.region": {
+      "type": "string"
+    },
+    "channels.imessage.remoteHost": {
+      "type": "string"
+    },
+    "channels.imessage.service": {
+      "type": "enum",
+      "values": [
+        "imessage",
+        "sms",
+        "auto"
+      ]
+    },
+    "channels.imessage.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.msteams": {
+      "type": "object"
+    },
+    "channels.msteams.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.appId": {
+      "type": "string"
+    },
+    "channels.msteams.appPassword": {
+      "type": "string"
+    },
+    "channels.msteams.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.msteams.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.msteams.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.msteams.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.msteams.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.msteams.configWrites": {
+      "type": "boolean"
+    },
+    "channels.msteams.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.msteams.dmPolicy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.msteams.dms": {
+      "type": "object"
+    },
+    "channels.msteams.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.msteams.enabled": {
+      "type": "boolean"
+    },
+    "channels.msteams.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.msteams.heartbeat": {
+      "type": "object"
+    },
+    "channels.msteams.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.msteams.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.msteams.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.msteams.historyLimit": {
+      "type": "integer"
+    },
+    "channels.msteams.markdown": {
+      "type": "object"
+    },
+    "channels.msteams.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.msteams.mediaAllowHosts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.mediaMaxMb": {
+      "type": "number"
+    },
+    "channels.msteams.replyStyle": {
+      "type": "enum",
+      "values": [
+        "thread",
+        "top-level"
+      ]
+    },
+    "channels.msteams.requireMention": {
+      "type": "boolean"
+    },
+    "channels.msteams.sharePointSiteId": {
+      "type": "string"
+    },
+    "channels.msteams.teams": {
+      "type": "object"
+    },
+    "channels.msteams.teams.*.channels": {
+      "type": "object"
+    },
+    "channels.msteams.teams.*.channels.*.replyStyle": {
+      "type": "enum",
+      "values": [
+        "thread",
+        "top-level"
+      ]
+    },
+    "channels.msteams.teams.*.channels.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.msteams.teams.*.channels.*.tools": {
+      "type": "object"
+    },
+    "channels.msteams.teams.*.channels.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.teams.*.channels.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.teams.*.channels.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.teams.*.channels.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.msteams.teams.*.channels.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.teams.*.channels.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.teams.*.channels.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.teams.*.replyStyle": {
+      "type": "enum",
+      "values": [
+        "thread",
+        "top-level"
+      ]
+    },
+    "channels.msteams.teams.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.msteams.teams.*.tools": {
+      "type": "object"
+    },
+    "channels.msteams.teams.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.teams.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.teams.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.teams.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.msteams.teams.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.teams.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.teams.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.msteams.tenantId": {
+      "type": "string"
+    },
+    "channels.msteams.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.msteams.webhook": {
+      "type": "object"
+    },
+    "channels.msteams.webhook.path": {
+      "type": "string"
+    },
+    "channels.msteams.webhook.port": {
+      "type": "integer"
+    },
+    "channels.signal": {
+      "type": "object"
+    },
+    "channels.signal.account": {
+      "type": "string"
+    },
+    "channels.signal.accounts": {
+      "type": "object"
+    },
+    "channels.signal.accounts.*.account": {
+      "type": "string"
+    },
+    "channels.signal.accounts.*.actions": {
+      "type": "object"
+    },
+    "channels.signal.accounts.*.actions.reactions": {
+      "type": "boolean"
+    },
+    "channels.signal.accounts.*.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.signal.accounts.*.autoStart": {
+      "type": "boolean"
+    },
+    "channels.signal.accounts.*.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.signal.accounts.*.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.signal.accounts.*.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.signal.accounts.*.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.signal.accounts.*.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.signal.accounts.*.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.signal.accounts.*.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.signal.accounts.*.cliPath": {
+      "type": "string"
+    },
+    "channels.signal.accounts.*.configWrites": {
+      "type": "boolean"
+    },
+    "channels.signal.accounts.*.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.signal.accounts.*.dmPolicy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.signal.accounts.*.dms": {
+      "type": "object"
+    },
+    "channels.signal.accounts.*.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.signal.accounts.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.signal.accounts.*.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.signal.accounts.*.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.signal.accounts.*.heartbeat": {
+      "type": "object"
+    },
+    "channels.signal.accounts.*.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.signal.accounts.*.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.signal.accounts.*.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.signal.accounts.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.signal.accounts.*.httpHost": {
+      "type": "string"
+    },
+    "channels.signal.accounts.*.httpPort": {
+      "type": "integer"
+    },
+    "channels.signal.accounts.*.httpUrl": {
+      "type": "string"
+    },
+    "channels.signal.accounts.*.ignoreAttachments": {
+      "type": "boolean"
+    },
+    "channels.signal.accounts.*.ignoreStories": {
+      "type": "boolean"
+    },
+    "channels.signal.accounts.*.markdown": {
+      "type": "object"
+    },
+    "channels.signal.accounts.*.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.signal.accounts.*.mediaMaxMb": {
+      "type": "integer"
+    },
+    "channels.signal.accounts.*.name": {
+      "type": "string"
+    },
+    "channels.signal.accounts.*.reactionAllowlist": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.signal.accounts.*.reactionLevel": {
+      "type": "enum",
+      "values": [
+        "off",
+        "ack",
+        "minimal",
+        "extensive"
+      ]
+    },
+    "channels.signal.accounts.*.reactionNotifications": {
+      "type": "enum",
+      "values": [
+        "off",
+        "own",
+        "all",
+        "allowlist"
+      ]
+    },
+    "channels.signal.accounts.*.receiveMode": {
+      "type": "enum",
+      "values": [
+        "on-start",
+        "manual"
+      ]
+    },
+    "channels.signal.accounts.*.sendReadReceipts": {
+      "type": "boolean"
+    },
+    "channels.signal.accounts.*.startupTimeoutMs": {
+      "type": "integer"
+    },
+    "channels.signal.accounts.*.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.signal.actions": {
+      "type": "object"
+    },
+    "channels.signal.actions.reactions": {
+      "type": "boolean"
+    },
+    "channels.signal.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.signal.autoStart": {
+      "type": "boolean"
+    },
+    "channels.signal.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.signal.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.signal.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.signal.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.signal.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.signal.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.signal.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.signal.cliPath": {
+      "type": "string"
+    },
+    "channels.signal.configWrites": {
+      "type": "boolean"
+    },
+    "channels.signal.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.signal.dmPolicy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.signal.dms": {
+      "type": "object"
+    },
+    "channels.signal.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.signal.enabled": {
+      "type": "boolean"
+    },
+    "channels.signal.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.signal.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.signal.heartbeat": {
+      "type": "object"
+    },
+    "channels.signal.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.signal.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.signal.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.signal.historyLimit": {
+      "type": "integer"
+    },
+    "channels.signal.httpHost": {
+      "type": "string"
+    },
+    "channels.signal.httpPort": {
+      "type": "integer"
+    },
+    "channels.signal.httpUrl": {
+      "type": "string"
+    },
+    "channels.signal.ignoreAttachments": {
+      "type": "boolean"
+    },
+    "channels.signal.ignoreStories": {
+      "type": "boolean"
+    },
+    "channels.signal.markdown": {
+      "type": "object"
+    },
+    "channels.signal.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.signal.mediaMaxMb": {
+      "type": "integer"
+    },
+    "channels.signal.name": {
+      "type": "string"
+    },
+    "channels.signal.reactionAllowlist": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.signal.reactionLevel": {
+      "type": "enum",
+      "values": [
+        "off",
+        "ack",
+        "minimal",
+        "extensive"
+      ]
+    },
+    "channels.signal.reactionNotifications": {
+      "type": "enum",
+      "values": [
+        "off",
+        "own",
+        "all",
+        "allowlist"
+      ]
+    },
+    "channels.signal.receiveMode": {
+      "type": "enum",
+      "values": [
+        "on-start",
+        "manual"
+      ]
+    },
+    "channels.signal.sendReadReceipts": {
+      "type": "boolean"
+    },
+    "channels.signal.startupTimeoutMs": {
+      "type": "integer"
+    },
+    "channels.signal.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.slack": {
+      "type": "object"
+    },
+    "channels.slack.accounts": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.actions": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.actions.channelInfo": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.actions.emojiList": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.actions.memberInfo": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.actions.messages": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.actions.permissions": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.actions.pins": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.actions.reactions": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.actions.search": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.allowBots": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.appToken": {
+      "type": "string"
+    },
+    "channels.slack.accounts.*.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.slack.accounts.*.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.slack.accounts.*.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.slack.accounts.*.botToken": {
+      "type": "string"
+    },
+    "channels.slack.accounts.*.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.accounts.*.channels": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.channels.*.allow": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.channels.*.allowBots": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.channels.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.channels.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.channels.*.skills": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.accounts.*.channels.*.systemPrompt": {
+      "type": "string"
+    },
+    "channels.slack.accounts.*.channels.*.tools": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.channels.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.accounts.*.channels.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.accounts.*.channels.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.accounts.*.channels.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.channels.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.accounts.*.channels.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.accounts.*.channels.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.accounts.*.channels.*.users": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.slack.accounts.*.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.slack.accounts.*.commands": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.commands.native": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "channels.slack.accounts.*.commands.nativeSkills": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "channels.slack.accounts.*.configWrites": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.dm": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.dm.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.slack.accounts.*.dm.enabled": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.dm.groupChannels": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.slack.accounts.*.dm.groupEnabled": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.dm.policy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.slack.accounts.*.dm.replyToMode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.slack.accounts.*.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.slack.accounts.*.dms": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.slack.accounts.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.slack.accounts.*.heartbeat": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.slack.accounts.*.markdown": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.slack.accounts.*.mediaMaxMb": {
+      "type": "number"
+    },
+    "channels.slack.accounts.*.mode": {
+      "type": "enum",
+      "values": [
+        "socket",
+        "http"
+      ]
+    },
+    "channels.slack.accounts.*.name": {
+      "type": "string"
+    },
+    "channels.slack.accounts.*.reactionAllowlist": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.slack.accounts.*.reactionNotifications": {
+      "type": "enum",
+      "values": [
+        "off",
+        "own",
+        "all",
+        "allowlist"
+      ]
+    },
+    "channels.slack.accounts.*.replyToMode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.slack.accounts.*.replyToModeByChatType": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.replyToModeByChatType.channel": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.slack.accounts.*.replyToModeByChatType.direct": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.slack.accounts.*.replyToModeByChatType.group": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.slack.accounts.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.signingSecret": {
+      "type": "string"
+    },
+    "channels.slack.accounts.*.slashCommand": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.slashCommand.enabled": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.slashCommand.ephemeral": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.slashCommand.name": {
+      "type": "string"
+    },
+    "channels.slack.accounts.*.slashCommand.sessionPrefix": {
+      "type": "string"
+    },
+    "channels.slack.accounts.*.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.slack.accounts.*.thread": {
+      "type": "object"
+    },
+    "channels.slack.accounts.*.thread.historyScope": {
+      "type": "enum",
+      "values": [
+        "thread",
+        "channel"
+      ]
+    },
+    "channels.slack.accounts.*.thread.inheritParent": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.userToken": {
+      "type": "string"
+    },
+    "channels.slack.accounts.*.userTokenReadOnly": {
+      "type": "boolean"
+    },
+    "channels.slack.accounts.*.webhookPath": {
+      "type": "string"
+    },
+    "channels.slack.actions": {
+      "type": "object"
+    },
+    "channels.slack.actions.channelInfo": {
+      "type": "boolean"
+    },
+    "channels.slack.actions.emojiList": {
+      "type": "boolean"
+    },
+    "channels.slack.actions.memberInfo": {
+      "type": "boolean"
+    },
+    "channels.slack.actions.messages": {
+      "type": "boolean"
+    },
+    "channels.slack.actions.permissions": {
+      "type": "boolean"
+    },
+    "channels.slack.actions.pins": {
+      "type": "boolean"
+    },
+    "channels.slack.actions.reactions": {
+      "type": "boolean"
+    },
+    "channels.slack.actions.search": {
+      "type": "boolean"
+    },
+    "channels.slack.allowBots": {
+      "type": "boolean"
+    },
+    "channels.slack.appToken": {
+      "type": "string"
+    },
+    "channels.slack.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.slack.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.slack.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.slack.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.slack.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.slack.botToken": {
+      "type": "string"
+    },
+    "channels.slack.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.channels": {
+      "type": "object"
+    },
+    "channels.slack.channels.*.allow": {
+      "type": "boolean"
+    },
+    "channels.slack.channels.*.allowBots": {
+      "type": "boolean"
+    },
+    "channels.slack.channels.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.slack.channels.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.slack.channels.*.skills": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.channels.*.systemPrompt": {
+      "type": "string"
+    },
+    "channels.slack.channels.*.tools": {
+      "type": "object"
+    },
+    "channels.slack.channels.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.channels.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.channels.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.channels.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.slack.channels.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.channels.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.channels.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.slack.channels.*.users": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.slack.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.slack.commands": {
+      "type": "object"
+    },
+    "channels.slack.commands.native": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "channels.slack.commands.nativeSkills": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "channels.slack.configWrites": {
+      "type": "boolean"
+    },
+    "channels.slack.dm": {
+      "type": "object"
+    },
+    "channels.slack.dm.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.slack.dm.enabled": {
+      "type": "boolean"
+    },
+    "channels.slack.dm.groupChannels": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.slack.dm.groupEnabled": {
+      "type": "boolean"
+    },
+    "channels.slack.dm.policy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.slack.dm.replyToMode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.slack.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.slack.dms": {
+      "type": "object"
+    },
+    "channels.slack.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.slack.enabled": {
+      "type": "boolean"
+    },
+    "channels.slack.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.slack.heartbeat": {
+      "type": "object"
+    },
+    "channels.slack.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.slack.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.slack.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.slack.historyLimit": {
+      "type": "integer"
+    },
+    "channels.slack.markdown": {
+      "type": "object"
+    },
+    "channels.slack.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.slack.mediaMaxMb": {
+      "type": "number"
+    },
+    "channels.slack.mode": {
+      "type": "enum",
+      "values": [
+        "socket",
+        "http"
+      ]
+    },
+    "channels.slack.name": {
+      "type": "string"
+    },
+    "channels.slack.reactionAllowlist": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.slack.reactionNotifications": {
+      "type": "enum",
+      "values": [
+        "off",
+        "own",
+        "all",
+        "allowlist"
+      ]
+    },
+    "channels.slack.replyToMode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.slack.replyToModeByChatType": {
+      "type": "object"
+    },
+    "channels.slack.replyToModeByChatType.channel": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.slack.replyToModeByChatType.direct": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.slack.replyToModeByChatType.group": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.slack.requireMention": {
+      "type": "boolean"
+    },
+    "channels.slack.signingSecret": {
+      "type": "string"
+    },
+    "channels.slack.slashCommand": {
+      "type": "object"
+    },
+    "channels.slack.slashCommand.enabled": {
+      "type": "boolean"
+    },
+    "channels.slack.slashCommand.ephemeral": {
+      "type": "boolean"
+    },
+    "channels.slack.slashCommand.name": {
+      "type": "string"
+    },
+    "channels.slack.slashCommand.sessionPrefix": {
+      "type": "string"
+    },
+    "channels.slack.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.slack.thread": {
+      "type": "object"
+    },
+    "channels.slack.thread.historyScope": {
+      "type": "enum",
+      "values": [
+        "thread",
+        "channel"
+      ]
+    },
+    "channels.slack.thread.inheritParent": {
+      "type": "boolean"
+    },
+    "channels.slack.userToken": {
+      "type": "string"
+    },
+    "channels.slack.userTokenReadOnly": {
+      "type": "boolean"
+    },
+    "channels.slack.webhookPath": {
+      "type": "string"
+    },
+    "channels.telegram": {
+      "type": "object"
+    },
+    "channels.telegram.accounts": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.actions": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.actions.deleteMessage": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.actions.reactions": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.actions.sendMessage": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.actions.sticker": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.telegram.accounts.*.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.botToken": {
+      "type": "string"
+    },
+    "channels.telegram.accounts.*.capabilities": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "channels.telegram.accounts.*.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.telegram.accounts.*.commands": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.commands.native": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "channels.telegram.accounts.*.commands.nativeSkills": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "channels.telegram.accounts.*.configWrites": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.customCommands": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "channels.telegram.accounts.*.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.dmPolicy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.telegram.accounts.*.dms": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.draftChunk": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.draftChunk.breakPreference": {
+      "type": "enum",
+      "values": [
+        "paragraph",
+        "newline",
+        "sentence"
+      ]
+    },
+    "channels.telegram.accounts.*.draftChunk.maxChars": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.draftChunk.minChars": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.telegram.accounts.*.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.telegram.accounts.*.groups": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.groups.*.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.telegram.accounts.*.groups.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.groups.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.groups.*.skills": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.accounts.*.groups.*.systemPrompt": {
+      "type": "string"
+    },
+    "channels.telegram.accounts.*.groups.*.tools": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.groups.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.accounts.*.groups.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.accounts.*.groups.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.accounts.*.groups.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.groups.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.accounts.*.groups.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.accounts.*.groups.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.accounts.*.groups.*.topics": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.groups.*.topics.*.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.telegram.accounts.*.groups.*.topics.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.groups.*.topics.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.groups.*.topics.*.skills": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.accounts.*.groups.*.topics.*.systemPrompt": {
+      "type": "string"
+    },
+    "channels.telegram.accounts.*.heartbeat": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.linkPreview": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.markdown": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.telegram.accounts.*.mediaMaxMb": {
+      "type": "number"
+    },
+    "channels.telegram.accounts.*.name": {
+      "type": "string"
+    },
+    "channels.telegram.accounts.*.network": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.network.autoSelectFamily": {
+      "type": "boolean"
+    },
+    "channels.telegram.accounts.*.proxy": {
+      "type": "string"
+    },
+    "channels.telegram.accounts.*.reactionLevel": {
+      "type": "enum",
+      "values": [
+        "off",
+        "ack",
+        "minimal",
+        "extensive"
+      ]
+    },
+    "channels.telegram.accounts.*.reactionNotifications": {
+      "type": "enum",
+      "values": [
+        "off",
+        "own",
+        "all"
+      ]
+    },
+    "channels.telegram.accounts.*.replyToMode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.telegram.accounts.*.retry": {
+      "type": "object"
+    },
+    "channels.telegram.accounts.*.retry.attempts": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.retry.jitter": {
+      "type": "number"
+    },
+    "channels.telegram.accounts.*.retry.maxDelayMs": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.retry.minDelayMs": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.streamMode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "partial",
+        "block"
+      ]
+    },
+    "channels.telegram.accounts.*.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.timeoutSeconds": {
+      "type": "integer"
+    },
+    "channels.telegram.accounts.*.tokenFile": {
+      "type": "string"
+    },
+    "channels.telegram.accounts.*.webhookPath": {
+      "type": "string"
+    },
+    "channels.telegram.accounts.*.webhookSecret": {
+      "type": "string"
+    },
+    "channels.telegram.accounts.*.webhookUrl": {
+      "type": "string"
+    },
+    "channels.telegram.actions": {
+      "type": "object"
+    },
+    "channels.telegram.actions.deleteMessage": {
+      "type": "boolean"
+    },
+    "channels.telegram.actions.reactions": {
+      "type": "boolean"
+    },
+    "channels.telegram.actions.sendMessage": {
+      "type": "boolean"
+    },
+    "channels.telegram.actions.sticker": {
+      "type": "boolean"
+    },
+    "channels.telegram.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.telegram.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.telegram.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.telegram.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.telegram.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.telegram.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.telegram.botToken": {
+      "type": "string"
+    },
+    "channels.telegram.capabilities": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "channels.telegram.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.telegram.commands": {
+      "type": "object"
+    },
+    "channels.telegram.commands.native": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "channels.telegram.commands.nativeSkills": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "channels.telegram.configWrites": {
+      "type": "boolean"
+    },
+    "channels.telegram.customCommands": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "channels.telegram.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.telegram.dmPolicy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.telegram.dms": {
+      "type": "object"
+    },
+    "channels.telegram.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.telegram.draftChunk": {
+      "type": "object"
+    },
+    "channels.telegram.draftChunk.breakPreference": {
+      "type": "enum",
+      "values": [
+        "paragraph",
+        "newline",
+        "sentence"
+      ]
+    },
+    "channels.telegram.draftChunk.maxChars": {
+      "type": "integer"
+    },
+    "channels.telegram.draftChunk.minChars": {
+      "type": "integer"
+    },
+    "channels.telegram.enabled": {
+      "type": "boolean"
+    },
+    "channels.telegram.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.telegram.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.telegram.groups": {
+      "type": "object"
+    },
+    "channels.telegram.groups.*.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.telegram.groups.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.telegram.groups.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.telegram.groups.*.skills": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.groups.*.systemPrompt": {
+      "type": "string"
+    },
+    "channels.telegram.groups.*.tools": {
+      "type": "object"
+    },
+    "channels.telegram.groups.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.groups.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.groups.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.groups.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.telegram.groups.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.groups.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.groups.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.groups.*.topics": {
+      "type": "object"
+    },
+    "channels.telegram.groups.*.topics.*.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "oneOf",
+        "alternatives": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "channels.telegram.groups.*.topics.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.telegram.groups.*.topics.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.telegram.groups.*.topics.*.skills": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.telegram.groups.*.topics.*.systemPrompt": {
+      "type": "string"
+    },
+    "channels.telegram.heartbeat": {
+      "type": "object"
+    },
+    "channels.telegram.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.telegram.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.telegram.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.telegram.historyLimit": {
+      "type": "integer"
+    },
+    "channels.telegram.linkPreview": {
+      "type": "boolean"
+    },
+    "channels.telegram.markdown": {
+      "type": "object"
+    },
+    "channels.telegram.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.telegram.mediaMaxMb": {
+      "type": "number"
+    },
+    "channels.telegram.name": {
+      "type": "string"
+    },
+    "channels.telegram.network": {
+      "type": "object"
+    },
+    "channels.telegram.network.autoSelectFamily": {
+      "type": "boolean"
+    },
+    "channels.telegram.proxy": {
+      "type": "string"
+    },
+    "channels.telegram.reactionLevel": {
+      "type": "enum",
+      "values": [
+        "off",
+        "ack",
+        "minimal",
+        "extensive"
+      ]
+    },
+    "channels.telegram.reactionNotifications": {
+      "type": "enum",
+      "values": [
+        "off",
+        "own",
+        "all"
+      ]
+    },
+    "channels.telegram.replyToMode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "first",
+        "all"
+      ]
+    },
+    "channels.telegram.retry": {
+      "type": "object"
+    },
+    "channels.telegram.retry.attempts": {
+      "type": "integer"
+    },
+    "channels.telegram.retry.jitter": {
+      "type": "number"
+    },
+    "channels.telegram.retry.maxDelayMs": {
+      "type": "integer"
+    },
+    "channels.telegram.retry.minDelayMs": {
+      "type": "integer"
+    },
+    "channels.telegram.streamMode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "partial",
+        "block"
+      ]
+    },
+    "channels.telegram.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.telegram.timeoutSeconds": {
+      "type": "integer"
+    },
+    "channels.telegram.tokenFile": {
+      "type": "string"
+    },
+    "channels.telegram.webhookPath": {
+      "type": "string"
+    },
+    "channels.telegram.webhookSecret": {
+      "type": "string"
+    },
+    "channels.telegram.webhookUrl": {
+      "type": "string"
+    },
+    "channels.whatsapp": {
+      "type": "object"
+    },
+    "channels.whatsapp.accounts": {
+      "type": "object"
+    },
+    "channels.whatsapp.accounts.*.ackReaction": {
+      "type": "object"
+    },
+    "channels.whatsapp.accounts.*.ackReaction.direct": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.accounts.*.ackReaction.emoji": {
+      "type": "string"
+    },
+    "channels.whatsapp.accounts.*.ackReaction.group": {
+      "type": "enum",
+      "values": [
+        "always",
+        "mentions",
+        "never"
+      ]
+    },
+    "channels.whatsapp.accounts.*.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.accounts.*.authDir": {
+      "type": "string"
+    },
+    "channels.whatsapp.accounts.*.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.accounts.*.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.whatsapp.accounts.*.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.whatsapp.accounts.*.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.whatsapp.accounts.*.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.whatsapp.accounts.*.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.accounts.*.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.whatsapp.accounts.*.configWrites": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.accounts.*.debounceMs": {
+      "type": "integer"
+    },
+    "channels.whatsapp.accounts.*.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.whatsapp.accounts.*.dmPolicy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.whatsapp.accounts.*.dms": {
+      "type": "object"
+    },
+    "channels.whatsapp.accounts.*.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.whatsapp.accounts.*.enabled": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.accounts.*.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.accounts.*.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.whatsapp.accounts.*.groups": {
+      "type": "object"
+    },
+    "channels.whatsapp.accounts.*.groups.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.accounts.*.groups.*.tools": {
+      "type": "object"
+    },
+    "channels.whatsapp.accounts.*.groups.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.accounts.*.groups.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.accounts.*.groups.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.accounts.*.groups.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.whatsapp.accounts.*.groups.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.accounts.*.groups.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.accounts.*.groups.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.accounts.*.heartbeat": {
+      "type": "object"
+    },
+    "channels.whatsapp.accounts.*.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.accounts.*.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.accounts.*.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.accounts.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.whatsapp.accounts.*.markdown": {
+      "type": "object"
+    },
+    "channels.whatsapp.accounts.*.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.whatsapp.accounts.*.mediaMaxMb": {
+      "type": "integer"
+    },
+    "channels.whatsapp.accounts.*.messagePrefix": {
+      "type": "string"
+    },
+    "channels.whatsapp.accounts.*.name": {
+      "type": "string"
+    },
+    "channels.whatsapp.accounts.*.selfChatMode": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.accounts.*.sendReadReceipts": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.accounts.*.textChunkLimit": {
+      "type": "integer"
+    },
+    "channels.whatsapp.ackReaction": {
+      "type": "object"
+    },
+    "channels.whatsapp.ackReaction.direct": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.ackReaction.emoji": {
+      "type": "string"
+    },
+    "channels.whatsapp.ackReaction.group": {
+      "type": "enum",
+      "values": [
+        "always",
+        "mentions",
+        "never"
+      ]
+    },
+    "channels.whatsapp.actions": {
+      "type": "object"
+    },
+    "channels.whatsapp.actions.polls": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.actions.reactions": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.actions.sendMessage": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.allowFrom": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.blockStreaming": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.blockStreamingCoalesce": {
+      "type": "object"
+    },
+    "channels.whatsapp.blockStreamingCoalesce.idleMs": {
+      "type": "integer"
+    },
+    "channels.whatsapp.blockStreamingCoalesce.maxChars": {
+      "type": "integer"
+    },
+    "channels.whatsapp.blockStreamingCoalesce.minChars": {
+      "type": "integer"
+    },
+    "channels.whatsapp.capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.chunkMode": {
+      "type": "enum",
+      "values": [
+        "length",
+        "newline"
+      ]
+    },
+    "channels.whatsapp.configWrites": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.debounceMs": {
+      "type": "integer"
+    },
+    "channels.whatsapp.dmHistoryLimit": {
+      "type": "integer"
+    },
+    "channels.whatsapp.dmPolicy": {
+      "type": "enum",
+      "values": [
+        "pairing",
+        "allowlist",
+        "open",
+        "disabled"
+      ]
+    },
+    "channels.whatsapp.dms": {
+      "type": "object"
+    },
+    "channels.whatsapp.dms.*.historyLimit": {
+      "type": "integer"
+    },
+    "channels.whatsapp.groupAllowFrom": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.groupPolicy": {
+      "type": "enum",
+      "values": [
+        "open",
+        "disabled",
+        "allowlist"
+      ]
+    },
+    "channels.whatsapp.groups": {
+      "type": "object"
+    },
+    "channels.whatsapp.groups.*.requireMention": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.groups.*.tools": {
+      "type": "object"
+    },
+    "channels.whatsapp.groups.*.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.groups.*.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.groups.*.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.groups.*.toolsBySender": {
+      "type": "object"
+    },
+    "channels.whatsapp.groups.*.toolsBySender.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.groups.*.toolsBySender.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.groups.*.toolsBySender.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "channels.whatsapp.heartbeat": {
+      "type": "object"
+    },
+    "channels.whatsapp.heartbeat.showAlerts": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.heartbeat.showOk": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.heartbeat.useIndicator": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.historyLimit": {
+      "type": "integer"
+    },
+    "channels.whatsapp.markdown": {
+      "type": "object"
+    },
+    "channels.whatsapp.markdown.tables": {
+      "type": "enum",
+      "values": [
+        "off",
+        "bullets",
+        "code"
+      ]
+    },
+    "channels.whatsapp.mediaMaxMb": {
+      "type": "integer"
+    },
+    "channels.whatsapp.messagePrefix": {
+      "type": "string"
+    },
+    "channels.whatsapp.selfChatMode": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.sendReadReceipts": {
+      "type": "boolean"
+    },
+    "channels.whatsapp.textChunkLimit": {
+      "type": "integer"
+    },
+    "commands": {
+      "type": "object"
+    },
+    "commands.bash": {
+      "type": "boolean"
+    },
+    "commands.bashForegroundMs": {
+      "type": "integer"
+    },
+    "commands.config": {
+      "type": "boolean"
+    },
+    "commands.debug": {
+      "type": "boolean"
+    },
+    "commands.native": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "commands.nativeSkills": {
+      "type": "oneOf",
+      "alternatives": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "enum",
+          "values": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "commands.restart": {
+      "type": "boolean"
+    },
+    "commands.text": {
+      "type": "boolean"
+    },
+    "commands.useAccessGroups": {
+      "type": "boolean"
+    },
+    "cron": {
+      "type": "object"
+    },
+    "cron.enabled": {
+      "type": "boolean"
+    },
+    "cron.maxConcurrentRuns": {
+      "type": "integer"
+    },
+    "cron.store": {
+      "type": "string"
+    },
+    "diagnostics": {
+      "type": "object"
+    },
+    "diagnostics.cacheTrace": {
+      "type": "object"
+    },
+    "diagnostics.cacheTrace.enabled": {
+      "type": "boolean"
+    },
+    "diagnostics.cacheTrace.filePath": {
+      "type": "string"
+    },
+    "diagnostics.cacheTrace.includeMessages": {
+      "type": "boolean"
+    },
+    "diagnostics.cacheTrace.includePrompt": {
+      "type": "boolean"
+    },
+    "diagnostics.cacheTrace.includeSystem": {
+      "type": "boolean"
+    },
+    "diagnostics.enabled": {
+      "type": "boolean"
+    },
+    "diagnostics.flags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "diagnostics.otel": {
+      "type": "object"
+    },
+    "diagnostics.otel.enabled": {
+      "type": "boolean"
+    },
+    "diagnostics.otel.endpoint": {
+      "type": "string"
+    },
+    "diagnostics.otel.flushIntervalMs": {
+      "type": "integer"
+    },
+    "diagnostics.otel.headers": {
+      "type": "object"
+    },
+    "diagnostics.otel.logs": {
+      "type": "boolean"
+    },
+    "diagnostics.otel.metrics": {
+      "type": "boolean"
+    },
+    "diagnostics.otel.protocol": {
+      "type": "enum",
+      "values": [
+        "http/protobuf",
+        "grpc"
+      ]
+    },
+    "diagnostics.otel.sampleRate": {
+      "type": "number"
+    },
+    "diagnostics.otel.serviceName": {
+      "type": "string"
+    },
+    "diagnostics.otel.traces": {
+      "type": "boolean"
+    },
+    "discovery": {
+      "type": "object"
+    },
+    "discovery.mdns": {
+      "type": "object"
+    },
+    "discovery.mdns.mode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "minimal",
+        "full"
+      ]
+    },
+    "discovery.wideArea": {
+      "type": "object"
+    },
+    "discovery.wideArea.domain": {
+      "type": "string"
+    },
+    "discovery.wideArea.enabled": {
+      "type": "boolean"
+    },
+    "env": {
+      "type": "object"
+    },
+    "env.shellEnv": {
+      "type": "object"
+    },
+    "env.shellEnv.enabled": {
+      "type": "boolean"
+    },
+    "env.shellEnv.timeoutMs": {
+      "type": "integer"
+    },
+    "env.vars": {
+      "type": "object"
+    },
+    "gateway": {
+      "type": "object"
+    },
+    "gateway.auth": {
+      "type": "object"
+    },
+    "gateway.auth.allowTailscale": {
+      "type": "boolean"
+    },
+    "gateway.auth.mode": {
+      "type": "enum",
+      "values": [
+        "token",
+        "password"
+      ]
+    },
+    "gateway.auth.password": {
+      "type": "string"
+    },
+    "gateway.auth.token": {
+      "type": "string"
+    },
+    "gateway.bind": {
+      "type": "enum",
+      "values": [
+        "auto",
+        "lan",
+        "loopback",
+        "custom",
+        "tailnet"
+      ]
+    },
+    "gateway.controlUi": {
+      "type": "object"
+    },
+    "gateway.controlUi.allowInsecureAuth": {
+      "type": "boolean"
+    },
+    "gateway.controlUi.basePath": {
+      "type": "string"
+    },
+    "gateway.controlUi.dangerouslyDisableDeviceAuth": {
+      "type": "boolean"
+    },
+    "gateway.controlUi.enabled": {
+      "type": "boolean"
+    },
+    "gateway.http": {
+      "type": "object"
+    },
+    "gateway.http.endpoints": {
+      "type": "object"
+    },
+    "gateway.http.endpoints.chatCompletions": {
+      "type": "object"
+    },
+    "gateway.http.endpoints.chatCompletions.enabled": {
+      "type": "boolean"
+    },
+    "gateway.http.endpoints.responses": {
+      "type": "object"
+    },
+    "gateway.http.endpoints.responses.enabled": {
+      "type": "boolean"
+    },
+    "gateway.http.endpoints.responses.files": {
+      "type": "object"
+    },
+    "gateway.http.endpoints.responses.files.allowUrl": {
+      "type": "boolean"
+    },
+    "gateway.http.endpoints.responses.files.allowedMimes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "gateway.http.endpoints.responses.files.maxBytes": {
+      "type": "integer"
+    },
+    "gateway.http.endpoints.responses.files.maxChars": {
+      "type": "integer"
+    },
+    "gateway.http.endpoints.responses.files.maxRedirects": {
+      "type": "integer"
+    },
+    "gateway.http.endpoints.responses.files.pdf": {
+      "type": "object"
+    },
+    "gateway.http.endpoints.responses.files.pdf.maxPages": {
+      "type": "integer"
+    },
+    "gateway.http.endpoints.responses.files.pdf.maxPixels": {
+      "type": "integer"
+    },
+    "gateway.http.endpoints.responses.files.pdf.minTextChars": {
+      "type": "integer"
+    },
+    "gateway.http.endpoints.responses.files.timeoutMs": {
+      "type": "integer"
+    },
+    "gateway.http.endpoints.responses.images": {
+      "type": "object"
+    },
+    "gateway.http.endpoints.responses.images.allowUrl": {
+      "type": "boolean"
+    },
+    "gateway.http.endpoints.responses.images.allowedMimes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "gateway.http.endpoints.responses.images.maxBytes": {
+      "type": "integer"
+    },
+    "gateway.http.endpoints.responses.images.maxRedirects": {
+      "type": "integer"
+    },
+    "gateway.http.endpoints.responses.images.timeoutMs": {
+      "type": "integer"
+    },
+    "gateway.http.endpoints.responses.maxBodyBytes": {
+      "type": "integer"
+    },
+    "gateway.mode": {
+      "type": "enum",
+      "values": [
+        "local",
+        "remote"
+      ]
+    },
+    "gateway.nodes": {
+      "type": "object"
+    },
+    "gateway.nodes.allowCommands": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "gateway.nodes.browser": {
+      "type": "object"
+    },
+    "gateway.nodes.browser.mode": {
+      "type": "enum",
+      "values": [
+        "auto",
+        "manual",
+        "off"
+      ]
+    },
+    "gateway.nodes.browser.node": {
+      "type": "string"
+    },
+    "gateway.nodes.denyCommands": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "gateway.port": {
+      "type": "integer"
+    },
+    "gateway.reload": {
+      "type": "object"
+    },
+    "gateway.reload.debounceMs": {
+      "type": "integer"
+    },
+    "gateway.reload.mode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "restart",
+        "hot",
+        "hybrid"
+      ]
+    },
+    "gateway.remote": {
+      "type": "object"
+    },
+    "gateway.remote.password": {
+      "type": "string"
+    },
+    "gateway.remote.sshIdentity": {
+      "type": "string"
+    },
+    "gateway.remote.sshTarget": {
+      "type": "string"
+    },
+    "gateway.remote.tlsFingerprint": {
+      "type": "string"
+    },
+    "gateway.remote.token": {
+      "type": "string"
+    },
+    "gateway.remote.transport": {
+      "type": "enum",
+      "values": [
+        "ssh",
+        "direct"
+      ]
+    },
+    "gateway.remote.url": {
+      "type": "string"
+    },
+    "gateway.tailscale": {
+      "type": "object"
+    },
+    "gateway.tailscale.mode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "serve",
+        "funnel"
+      ]
+    },
+    "gateway.tailscale.resetOnExit": {
+      "type": "boolean"
+    },
+    "gateway.tls": {
+      "type": "object"
+    },
+    "gateway.tls.autoGenerate": {
+      "type": "boolean"
+    },
+    "gateway.tls.caPath": {
+      "type": "string"
+    },
+    "gateway.tls.certPath": {
+      "type": "string"
+    },
+    "gateway.tls.enabled": {
+      "type": "boolean"
+    },
+    "gateway.tls.keyPath": {
+      "type": "string"
+    },
+    "gateway.trustedProxies": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hooks": {
+      "type": "object"
+    },
+    "hooks.enabled": {
+      "type": "boolean"
+    },
+    "hooks.gmail": {
+      "type": "object"
+    },
+    "hooks.gmail.account": {
+      "type": "string"
+    },
+    "hooks.gmail.allowUnsafeExternalContent": {
+      "type": "boolean"
+    },
+    "hooks.gmail.hookUrl": {
+      "type": "string"
+    },
+    "hooks.gmail.includeBody": {
+      "type": "boolean"
+    },
+    "hooks.gmail.label": {
+      "type": "string"
+    },
+    "hooks.gmail.maxBytes": {
+      "type": "integer"
+    },
+    "hooks.gmail.model": {
+      "type": "string"
+    },
+    "hooks.gmail.pushToken": {
+      "type": "string"
+    },
+    "hooks.gmail.renewEveryMinutes": {
+      "type": "integer"
+    },
+    "hooks.gmail.serve": {
+      "type": "object"
+    },
+    "hooks.gmail.serve.bind": {
+      "type": "string"
+    },
+    "hooks.gmail.serve.path": {
+      "type": "string"
+    },
+    "hooks.gmail.serve.port": {
+      "type": "integer"
+    },
+    "hooks.gmail.subscription": {
+      "type": "string"
+    },
+    "hooks.gmail.tailscale": {
+      "type": "object"
+    },
+    "hooks.gmail.tailscale.mode": {
+      "type": "enum",
+      "values": [
+        "off",
+        "serve",
+        "funnel"
+      ]
+    },
+    "hooks.gmail.tailscale.path": {
+      "type": "string"
+    },
+    "hooks.gmail.tailscale.target": {
+      "type": "string"
+    },
+    "hooks.gmail.thinking": {
+      "type": "enum",
+      "values": [
+        "off",
+        "minimal",
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "hooks.gmail.topic": {
+      "type": "string"
+    },
+    "hooks.internal": {
+      "type": "object"
+    },
+    "hooks.internal.enabled": {
+      "type": "boolean"
+    },
+    "hooks.internal.entries": {
+      "type": "object"
+    },
+    "hooks.internal.entries.*.enabled": {
+      "type": "boolean"
+    },
+    "hooks.internal.entries.*.env": {
+      "type": "object"
+    },
+    "hooks.internal.handlers": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "hooks.internal.installs": {
+      "type": "object"
+    },
+    "hooks.internal.installs.*.hooks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hooks.internal.installs.*.installPath": {
+      "type": "string"
+    },
+    "hooks.internal.installs.*.installedAt": {
+      "type": "string"
+    },
+    "hooks.internal.installs.*.source": {
+      "type": "enum",
+      "values": [
+        "npm",
+        "archive",
+        "path"
+      ]
+    },
+    "hooks.internal.installs.*.sourcePath": {
+      "type": "string"
+    },
+    "hooks.internal.installs.*.spec": {
+      "type": "string"
+    },
+    "hooks.internal.installs.*.version": {
+      "type": "string"
+    },
+    "hooks.internal.load": {
+      "type": "object"
+    },
+    "hooks.internal.load.extraDirs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hooks.mappings": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "hooks.maxBodyBytes": {
+      "type": "integer"
+    },
+    "hooks.path": {
+      "type": "string"
+    },
+    "hooks.presets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hooks.token": {
+      "type": "string"
+    },
+    "hooks.transformsDir": {
+      "type": "string"
+    },
+    "logging": {
+      "type": "object"
+    },
+    "logging.consoleLevel": {
+      "type": "enum",
+      "values": [
+        "silent",
+        "fatal",
+        "error",
+        "warn",
+        "info",
+        "debug",
+        "trace"
+      ]
+    },
+    "logging.consoleStyle": {
+      "type": "enum",
+      "values": [
+        "pretty",
+        "compact",
+        "json"
+      ]
+    },
+    "logging.file": {
+      "type": "string"
+    },
+    "logging.level": {
+      "type": "enum",
+      "values": [
+        "silent",
+        "fatal",
+        "error",
+        "warn",
+        "info",
+        "debug",
+        "trace"
+      ]
+    },
+    "logging.redactPatterns": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "logging.redactSensitive": {
+      "type": "enum",
+      "values": [
+        "off",
+        "tools"
+      ]
+    },
+    "media": {
+      "type": "object"
+    },
+    "media.preserveFilenames": {
+      "type": "boolean"
+    },
+    "messages": {
+      "type": "object"
+    },
+    "messages.ackReaction": {
+      "type": "string"
+    },
+    "messages.ackReactionScope": {
+      "type": "enum",
+      "values": [
+        "group-mentions",
+        "group-all",
+        "direct",
+        "all"
+      ]
+    },
+    "messages.groupChat": {
+      "type": "object"
+    },
+    "messages.groupChat.historyLimit": {
+      "type": "integer"
+    },
+    "messages.groupChat.mentionPatterns": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "messages.inbound": {
+      "type": "object"
+    },
+    "messages.inbound.byChannel": {
+      "type": "object"
+    },
+    "messages.inbound.debounceMs": {
+      "type": "integer"
+    },
+    "messages.messagePrefix": {
+      "type": "string"
+    },
+    "messages.queue": {
+      "type": "object"
+    },
+    "messages.queue.byChannel": {
+      "type": "object"
+    },
+    "messages.queue.byChannel.discord": {
+      "type": "enum",
+      "values": [
+        "steer",
+        "followup",
+        "collect",
+        "steer-backlog",
+        "steer+backlog",
+        "queue",
+        "interrupt"
+      ]
+    },
+    "messages.queue.byChannel.imessage": {
+      "type": "enum",
+      "values": [
+        "steer",
+        "followup",
+        "collect",
+        "steer-backlog",
+        "steer+backlog",
+        "queue",
+        "interrupt"
+      ]
+    },
+    "messages.queue.byChannel.mattermost": {
+      "type": "enum",
+      "values": [
+        "steer",
+        "followup",
+        "collect",
+        "steer-backlog",
+        "steer+backlog",
+        "queue",
+        "interrupt"
+      ]
+    },
+    "messages.queue.byChannel.msteams": {
+      "type": "enum",
+      "values": [
+        "steer",
+        "followup",
+        "collect",
+        "steer-backlog",
+        "steer+backlog",
+        "queue",
+        "interrupt"
+      ]
+    },
+    "messages.queue.byChannel.signal": {
+      "type": "enum",
+      "values": [
+        "steer",
+        "followup",
+        "collect",
+        "steer-backlog",
+        "steer+backlog",
+        "queue",
+        "interrupt"
+      ]
+    },
+    "messages.queue.byChannel.slack": {
+      "type": "enum",
+      "values": [
+        "steer",
+        "followup",
+        "collect",
+        "steer-backlog",
+        "steer+backlog",
+        "queue",
+        "interrupt"
+      ]
+    },
+    "messages.queue.byChannel.telegram": {
+      "type": "enum",
+      "values": [
+        "steer",
+        "followup",
+        "collect",
+        "steer-backlog",
+        "steer+backlog",
+        "queue",
+        "interrupt"
+      ]
+    },
+    "messages.queue.byChannel.webchat": {
+      "type": "enum",
+      "values": [
+        "steer",
+        "followup",
+        "collect",
+        "steer-backlog",
+        "steer+backlog",
+        "queue",
+        "interrupt"
+      ]
+    },
+    "messages.queue.byChannel.whatsapp": {
+      "type": "enum",
+      "values": [
+        "steer",
+        "followup",
+        "collect",
+        "steer-backlog",
+        "steer+backlog",
+        "queue",
+        "interrupt"
+      ]
+    },
+    "messages.queue.cap": {
+      "type": "integer"
+    },
+    "messages.queue.debounceMs": {
+      "type": "integer"
+    },
+    "messages.queue.debounceMsByChannel": {
+      "type": "object"
+    },
+    "messages.queue.drop": {
+      "type": "enum",
+      "values": [
+        "old",
+        "new",
+        "summarize"
+      ]
+    },
+    "messages.queue.mode": {
+      "type": "enum",
+      "values": [
+        "steer",
+        "followup",
+        "collect",
+        "steer-backlog",
+        "steer+backlog",
+        "queue",
+        "interrupt"
+      ]
+    },
+    "messages.removeAckAfterReply": {
+      "type": "boolean"
+    },
+    "messages.responsePrefix": {
+      "type": "string"
+    },
+    "messages.tts": {
+      "type": "object"
+    },
+    "messages.tts.auto": {
+      "type": "enum",
+      "values": [
+        "off",
+        "always",
+        "inbound",
+        "tagged"
+      ]
+    },
+    "messages.tts.edge": {
+      "type": "object"
+    },
+    "messages.tts.edge.enabled": {
+      "type": "boolean"
+    },
+    "messages.tts.edge.lang": {
+      "type": "string"
+    },
+    "messages.tts.edge.outputFormat": {
+      "type": "string"
+    },
+    "messages.tts.edge.pitch": {
+      "type": "string"
+    },
+    "messages.tts.edge.proxy": {
+      "type": "string"
+    },
+    "messages.tts.edge.rate": {
+      "type": "string"
+    },
+    "messages.tts.edge.saveSubtitles": {
+      "type": "boolean"
+    },
+    "messages.tts.edge.timeoutMs": {
+      "type": "integer"
+    },
+    "messages.tts.edge.voice": {
+      "type": "string"
+    },
+    "messages.tts.edge.volume": {
+      "type": "string"
+    },
+    "messages.tts.elevenlabs": {
+      "type": "object"
+    },
+    "messages.tts.elevenlabs.apiKey": {
+      "type": "string"
+    },
+    "messages.tts.elevenlabs.applyTextNormalization": {
+      "type": "enum",
+      "values": [
+        "auto",
+        "on",
+        "off"
+      ]
+    },
+    "messages.tts.elevenlabs.baseUrl": {
+      "type": "string"
+    },
+    "messages.tts.elevenlabs.languageCode": {
+      "type": "string"
+    },
+    "messages.tts.elevenlabs.modelId": {
+      "type": "string"
+    },
+    "messages.tts.elevenlabs.seed": {
+      "type": "integer"
+    },
+    "messages.tts.elevenlabs.voiceId": {
+      "type": "string"
+    },
+    "messages.tts.elevenlabs.voiceSettings": {
+      "type": "object"
+    },
+    "messages.tts.elevenlabs.voiceSettings.similarityBoost": {
+      "type": "number"
+    },
+    "messages.tts.elevenlabs.voiceSettings.speed": {
+      "type": "number"
+    },
+    "messages.tts.elevenlabs.voiceSettings.stability": {
+      "type": "number"
+    },
+    "messages.tts.elevenlabs.voiceSettings.style": {
+      "type": "number"
+    },
+    "messages.tts.elevenlabs.voiceSettings.useSpeakerBoost": {
+      "type": "boolean"
+    },
+    "messages.tts.enabled": {
+      "type": "boolean"
+    },
+    "messages.tts.maxTextLength": {
+      "type": "integer"
+    },
+    "messages.tts.mode": {
+      "type": "enum",
+      "values": [
+        "final",
+        "all"
+      ]
+    },
+    "messages.tts.modelOverrides": {
+      "type": "object"
+    },
+    "messages.tts.modelOverrides.allowModelId": {
+      "type": "boolean"
+    },
+    "messages.tts.modelOverrides.allowNormalization": {
+      "type": "boolean"
+    },
+    "messages.tts.modelOverrides.allowProvider": {
+      "type": "boolean"
+    },
+    "messages.tts.modelOverrides.allowSeed": {
+      "type": "boolean"
+    },
+    "messages.tts.modelOverrides.allowText": {
+      "type": "boolean"
+    },
+    "messages.tts.modelOverrides.allowVoice": {
+      "type": "boolean"
+    },
+    "messages.tts.modelOverrides.allowVoiceSettings": {
+      "type": "boolean"
+    },
+    "messages.tts.modelOverrides.enabled": {
+      "type": "boolean"
+    },
+    "messages.tts.openai": {
+      "type": "object"
+    },
+    "messages.tts.openai.apiKey": {
+      "type": "string"
+    },
+    "messages.tts.openai.model": {
+      "type": "string"
+    },
+    "messages.tts.openai.voice": {
+      "type": "string"
+    },
+    "messages.tts.prefsPath": {
+      "type": "string"
+    },
+    "messages.tts.provider": {
+      "type": "enum",
+      "values": [
+        "elevenlabs",
+        "openai",
+        "edge"
+      ]
+    },
+    "messages.tts.summaryModel": {
+      "type": "string"
+    },
+    "messages.tts.timeoutMs": {
+      "type": "integer"
+    },
+    "meta": {
+      "type": "object"
+    },
+    "meta.lastTouchedAt": {
+      "type": "string"
+    },
+    "meta.lastTouchedVersion": {
+      "type": "string"
+    },
+    "models": {
+      "type": "object"
+    },
+    "models.bedrockDiscovery": {
+      "type": "object"
+    },
+    "models.bedrockDiscovery.defaultContextWindow": {
+      "type": "integer"
+    },
+    "models.bedrockDiscovery.defaultMaxTokens": {
+      "type": "integer"
+    },
+    "models.bedrockDiscovery.enabled": {
+      "type": "boolean"
+    },
+    "models.bedrockDiscovery.providerFilter": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "models.bedrockDiscovery.refreshInterval": {
+      "type": "integer"
+    },
+    "models.bedrockDiscovery.region": {
+      "type": "string"
+    },
+    "models.mode": {
+      "type": "enum",
+      "values": [
+        "merge",
+        "replace"
+      ]
+    },
+    "models.providers": {
+      "type": "object"
+    },
+    "models.providers.*.api": {
+      "type": "enum",
+      "values": [
+        "openai-completions",
+        "openai-responses",
+        "anthropic-messages",
+        "google-generative-ai",
+        "github-copilot",
+        "bedrock-converse-stream"
+      ]
+    },
+    "models.providers.*.apiKey": {
+      "type": "string"
+    },
+    "models.providers.*.auth": {
+      "type": "enum",
+      "values": [
+        "api-key",
+        "aws-sdk",
+        "oauth",
+        "token"
+      ]
+    },
+    "models.providers.*.authHeader": {
+      "type": "boolean"
+    },
+    "models.providers.*.baseUrl": {
+      "type": "string"
+    },
+    "models.providers.*.headers": {
+      "type": "object"
+    },
+    "models.providers.*.models": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "nodeHost": {
+      "type": "object"
+    },
+    "nodeHost.browserProxy": {
+      "type": "object"
+    },
+    "nodeHost.browserProxy.allowProfiles": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "nodeHost.browserProxy.enabled": {
+      "type": "boolean"
+    },
+    "plugins": {
+      "type": "object"
+    },
+    "plugins.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "plugins.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "plugins.enabled": {
+      "type": "boolean"
+    },
+    "plugins.entries": {
+      "type": "object"
+    },
+    "plugins.entries.*.config": {
+      "type": "object"
+    },
+    "plugins.entries.*.enabled": {
+      "type": "boolean"
+    },
+    "plugins.installs": {
+      "type": "object"
+    },
+    "plugins.installs.*.installPath": {
+      "type": "string"
+    },
+    "plugins.installs.*.installedAt": {
+      "type": "string"
+    },
+    "plugins.installs.*.source": {
+      "type": "enum",
+      "values": [
+        "npm",
+        "archive",
+        "path"
+      ]
+    },
+    "plugins.installs.*.sourcePath": {
+      "type": "string"
+    },
+    "plugins.installs.*.spec": {
+      "type": "string"
+    },
+    "plugins.installs.*.version": {
+      "type": "string"
+    },
+    "plugins.load": {
+      "type": "object"
+    },
+    "plugins.load.paths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "plugins.slots": {
+      "type": "object"
+    },
+    "plugins.slots.memory": {
+      "type": "string"
+    },
+    "session": {
+      "type": "object"
+    },
+    "session.agentToAgent": {
+      "type": "object"
+    },
+    "session.agentToAgent.maxPingPongTurns": {
+      "type": "integer"
+    },
+    "session.dmScope": {
+      "type": "enum",
+      "values": [
+        "main",
+        "per-peer",
+        "per-channel-peer",
+        "per-account-channel-peer"
+      ]
+    },
+    "session.identityLinks": {
+      "type": "object"
+    },
+    "session.idleMinutes": {
+      "type": "integer"
+    },
+    "session.mainKey": {
+      "type": "string"
+    },
+    "session.reset": {
+      "type": "object"
+    },
+    "session.reset.atHour": {
+      "type": "integer"
+    },
+    "session.reset.idleMinutes": {
+      "type": "integer"
+    },
+    "session.reset.mode": {
+      "type": "enum",
+      "values": [
+        "daily",
+        "idle"
+      ]
+    },
+    "session.resetByChannel": {
+      "type": "object"
+    },
+    "session.resetByChannel.*.atHour": {
+      "type": "integer"
+    },
+    "session.resetByChannel.*.idleMinutes": {
+      "type": "integer"
+    },
+    "session.resetByChannel.*.mode": {
+      "type": "enum",
+      "values": [
+        "daily",
+        "idle"
+      ]
+    },
+    "session.resetByType": {
+      "type": "object"
+    },
+    "session.resetByType.dm": {
+      "type": "object"
+    },
+    "session.resetByType.dm.atHour": {
+      "type": "integer"
+    },
+    "session.resetByType.dm.idleMinutes": {
+      "type": "integer"
+    },
+    "session.resetByType.dm.mode": {
+      "type": "enum",
+      "values": [
+        "daily",
+        "idle"
+      ]
+    },
+    "session.resetByType.group": {
+      "type": "object"
+    },
+    "session.resetByType.group.atHour": {
+      "type": "integer"
+    },
+    "session.resetByType.group.idleMinutes": {
+      "type": "integer"
+    },
+    "session.resetByType.group.mode": {
+      "type": "enum",
+      "values": [
+        "daily",
+        "idle"
+      ]
+    },
+    "session.resetByType.thread": {
+      "type": "object"
+    },
+    "session.resetByType.thread.atHour": {
+      "type": "integer"
+    },
+    "session.resetByType.thread.idleMinutes": {
+      "type": "integer"
+    },
+    "session.resetByType.thread.mode": {
+      "type": "enum",
+      "values": [
+        "daily",
+        "idle"
+      ]
+    },
+    "session.resetTriggers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "session.scope": {
+      "type": "enum",
+      "values": [
+        "per-sender",
+        "global"
+      ]
+    },
+    "session.sendPolicy": {
+      "type": "object"
+    },
+    "session.sendPolicy.default": {
+      "type": "enum",
+      "values": [
+        "allow",
+        "deny"
+      ]
+    },
+    "session.sendPolicy.rules": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "session.store": {
+      "type": "string"
+    },
+    "session.typingIntervalSeconds": {
+      "type": "integer"
+    },
+    "session.typingMode": {
+      "type": "enum",
+      "values": [
+        "never",
+        "instant",
+        "thinking",
+        "message"
+      ]
+    },
+    "skills": {
+      "type": "object"
+    },
+    "skills.allowBundled": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "skills.entries": {
+      "type": "object"
+    },
+    "skills.entries.*.apiKey": {
+      "type": "string"
+    },
+    "skills.entries.*.config": {
+      "type": "object"
+    },
+    "skills.entries.*.enabled": {
+      "type": "boolean"
+    },
+    "skills.entries.*.env": {
+      "type": "object"
+    },
+    "skills.install": {
+      "type": "object"
+    },
+    "skills.install.nodeManager": {
+      "type": "enum",
+      "values": [
+        "npm",
+        "pnpm",
+        "yarn",
+        "bun"
+      ]
+    },
+    "skills.install.preferBrew": {
+      "type": "boolean"
+    },
+    "skills.load": {
+      "type": "object"
+    },
+    "skills.load.extraDirs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "skills.load.watch": {
+      "type": "boolean"
+    },
+    "skills.load.watchDebounceMs": {
+      "type": "integer"
+    },
+    "talk": {
+      "type": "object"
+    },
+    "talk.apiKey": {
+      "type": "string"
+    },
+    "talk.interruptOnSpeech": {
+      "type": "boolean"
+    },
+    "talk.modelId": {
+      "type": "string"
+    },
+    "talk.outputFormat": {
+      "type": "string"
+    },
+    "talk.voiceAliases": {
+      "type": "object"
+    },
+    "talk.voiceId": {
+      "type": "string"
+    },
+    "tools": {
+      "type": "object"
+    },
+    "tools.agentToAgent": {
+      "type": "object"
+    },
+    "tools.agentToAgent.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.agentToAgent.enabled": {
+      "type": "boolean"
+    },
+    "tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.byProvider": {
+      "type": "object"
+    },
+    "tools.byProvider.*.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.byProvider.*.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.byProvider.*.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.byProvider.*.profile": {
+      "type": "enum",
+      "values": [
+        "minimal",
+        "coding",
+        "messaging",
+        "full"
+      ]
+    },
+    "tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.elevated": {
+      "type": "object"
+    },
+    "tools.elevated.allowFrom": {
+      "type": "object"
+    },
+    "tools.elevated.enabled": {
+      "type": "boolean"
+    },
+    "tools.exec": {
+      "type": "object"
+    },
+    "tools.exec.applyPatch": {
+      "type": "object"
+    },
+    "tools.exec.applyPatch.allowModels": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.exec.applyPatch.enabled": {
+      "type": "boolean"
+    },
+    "tools.exec.ask": {
+      "type": "enum",
+      "values": [
+        "off",
+        "on-miss",
+        "always"
+      ]
+    },
+    "tools.exec.backgroundMs": {
+      "type": "integer"
+    },
+    "tools.exec.cleanupMs": {
+      "type": "integer"
+    },
+    "tools.exec.host": {
+      "type": "enum",
+      "values": [
+        "sandbox",
+        "gateway",
+        "node"
+      ]
+    },
+    "tools.exec.node": {
+      "type": "string"
+    },
+    "tools.exec.notifyOnExit": {
+      "type": "boolean"
+    },
+    "tools.exec.pathPrepend": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.exec.safeBins": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.exec.security": {
+      "type": "enum",
+      "values": [
+        "deny",
+        "allowlist",
+        "full"
+      ]
+    },
+    "tools.exec.timeoutSec": {
+      "type": "integer"
+    },
+    "tools.links": {
+      "type": "object"
+    },
+    "tools.links.enabled": {
+      "type": "boolean"
+    },
+    "tools.links.maxLinks": {
+      "type": "integer"
+    },
+    "tools.links.models": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "tools.links.scope": {
+      "type": "object"
+    },
+    "tools.links.scope.default": {
+      "type": "enum",
+      "values": [
+        "allow",
+        "deny"
+      ]
+    },
+    "tools.links.scope.rules": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "tools.links.timeoutSeconds": {
+      "type": "integer"
+    },
+    "tools.media": {
+      "type": "object"
+    },
+    "tools.media.audio": {
+      "type": "object"
+    },
+    "tools.media.audio.attachments": {
+      "type": "object"
+    },
+    "tools.media.audio.attachments.maxAttachments": {
+      "type": "integer"
+    },
+    "tools.media.audio.attachments.mode": {
+      "type": "enum",
+      "values": [
+        "first",
+        "all"
+      ]
+    },
+    "tools.media.audio.attachments.prefer": {
+      "type": "enum",
+      "values": [
+        "first",
+        "last",
+        "path",
+        "url"
+      ]
+    },
+    "tools.media.audio.baseUrl": {
+      "type": "string"
+    },
+    "tools.media.audio.deepgram": {
+      "type": "object"
+    },
+    "tools.media.audio.deepgram.detectLanguage": {
+      "type": "boolean"
+    },
+    "tools.media.audio.deepgram.punctuate": {
+      "type": "boolean"
+    },
+    "tools.media.audio.deepgram.smartFormat": {
+      "type": "boolean"
+    },
+    "tools.media.audio.enabled": {
+      "type": "boolean"
+    },
+    "tools.media.audio.headers": {
+      "type": "object"
+    },
+    "tools.media.audio.language": {
+      "type": "string"
+    },
+    "tools.media.audio.maxBytes": {
+      "type": "integer"
+    },
+    "tools.media.audio.maxChars": {
+      "type": "integer"
+    },
+    "tools.media.audio.models": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "tools.media.audio.prompt": {
+      "type": "string"
+    },
+    "tools.media.audio.providerOptions": {
+      "type": "object"
+    },
+    "tools.media.audio.scope": {
+      "type": "object"
+    },
+    "tools.media.audio.scope.default": {
+      "type": "enum",
+      "values": [
+        "allow",
+        "deny"
+      ]
+    },
+    "tools.media.audio.scope.rules": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "tools.media.audio.timeoutSeconds": {
+      "type": "integer"
+    },
+    "tools.media.concurrency": {
+      "type": "integer"
+    },
+    "tools.media.image": {
+      "type": "object"
+    },
+    "tools.media.image.attachments": {
+      "type": "object"
+    },
+    "tools.media.image.attachments.maxAttachments": {
+      "type": "integer"
+    },
+    "tools.media.image.attachments.mode": {
+      "type": "enum",
+      "values": [
+        "first",
+        "all"
+      ]
+    },
+    "tools.media.image.attachments.prefer": {
+      "type": "enum",
+      "values": [
+        "first",
+        "last",
+        "path",
+        "url"
+      ]
+    },
+    "tools.media.image.baseUrl": {
+      "type": "string"
+    },
+    "tools.media.image.deepgram": {
+      "type": "object"
+    },
+    "tools.media.image.deepgram.detectLanguage": {
+      "type": "boolean"
+    },
+    "tools.media.image.deepgram.punctuate": {
+      "type": "boolean"
+    },
+    "tools.media.image.deepgram.smartFormat": {
+      "type": "boolean"
+    },
+    "tools.media.image.enabled": {
+      "type": "boolean"
+    },
+    "tools.media.image.headers": {
+      "type": "object"
+    },
+    "tools.media.image.language": {
+      "type": "string"
+    },
+    "tools.media.image.maxBytes": {
+      "type": "integer"
+    },
+    "tools.media.image.maxChars": {
+      "type": "integer"
+    },
+    "tools.media.image.models": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "tools.media.image.prompt": {
+      "type": "string"
+    },
+    "tools.media.image.providerOptions": {
+      "type": "object"
+    },
+    "tools.media.image.scope": {
+      "type": "object"
+    },
+    "tools.media.image.scope.default": {
+      "type": "enum",
+      "values": [
+        "allow",
+        "deny"
+      ]
+    },
+    "tools.media.image.scope.rules": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "tools.media.image.timeoutSeconds": {
+      "type": "integer"
+    },
+    "tools.media.models": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "tools.media.video": {
+      "type": "object"
+    },
+    "tools.media.video.attachments": {
+      "type": "object"
+    },
+    "tools.media.video.attachments.maxAttachments": {
+      "type": "integer"
+    },
+    "tools.media.video.attachments.mode": {
+      "type": "enum",
+      "values": [
+        "first",
+        "all"
+      ]
+    },
+    "tools.media.video.attachments.prefer": {
+      "type": "enum",
+      "values": [
+        "first",
+        "last",
+        "path",
+        "url"
+      ]
+    },
+    "tools.media.video.baseUrl": {
+      "type": "string"
+    },
+    "tools.media.video.deepgram": {
+      "type": "object"
+    },
+    "tools.media.video.deepgram.detectLanguage": {
+      "type": "boolean"
+    },
+    "tools.media.video.deepgram.punctuate": {
+      "type": "boolean"
+    },
+    "tools.media.video.deepgram.smartFormat": {
+      "type": "boolean"
+    },
+    "tools.media.video.enabled": {
+      "type": "boolean"
+    },
+    "tools.media.video.headers": {
+      "type": "object"
+    },
+    "tools.media.video.language": {
+      "type": "string"
+    },
+    "tools.media.video.maxBytes": {
+      "type": "integer"
+    },
+    "tools.media.video.maxChars": {
+      "type": "integer"
+    },
+    "tools.media.video.models": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "tools.media.video.prompt": {
+      "type": "string"
+    },
+    "tools.media.video.providerOptions": {
+      "type": "object"
+    },
+    "tools.media.video.scope": {
+      "type": "object"
+    },
+    "tools.media.video.scope.default": {
+      "type": "enum",
+      "values": [
+        "allow",
+        "deny"
+      ]
+    },
+    "tools.media.video.scope.rules": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "tools.media.video.timeoutSeconds": {
+      "type": "integer"
+    },
+    "tools.message": {
+      "type": "object"
+    },
+    "tools.message.allowCrossContextSend": {
+      "type": "boolean"
+    },
+    "tools.message.broadcast": {
+      "type": "object"
+    },
+    "tools.message.broadcast.enabled": {
+      "type": "boolean"
+    },
+    "tools.message.crossContext": {
+      "type": "object"
+    },
+    "tools.message.crossContext.allowAcrossProviders": {
+      "type": "boolean"
+    },
+    "tools.message.crossContext.allowWithinProvider": {
+      "type": "boolean"
+    },
+    "tools.message.crossContext.marker": {
+      "type": "object"
+    },
+    "tools.message.crossContext.marker.enabled": {
+      "type": "boolean"
+    },
+    "tools.message.crossContext.marker.prefix": {
+      "type": "string"
+    },
+    "tools.message.crossContext.marker.suffix": {
+      "type": "string"
+    },
+    "tools.profile": {
+      "type": "enum",
+      "values": [
+        "minimal",
+        "coding",
+        "messaging",
+        "full"
+      ]
+    },
+    "tools.sandbox": {
+      "type": "object"
+    },
+    "tools.sandbox.tools": {
+      "type": "object"
+    },
+    "tools.sandbox.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.sandbox.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.sandbox.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.subagents": {
+      "type": "object"
+    },
+    "tools.subagents.tools": {
+      "type": "object"
+    },
+    "tools.subagents.tools.allow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.subagents.tools.alsoAllow": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.subagents.tools.deny": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools.web": {
+      "type": "object"
+    },
+    "tools.web.fetch": {
+      "type": "object"
+    },
+    "tools.web.fetch.cacheTtlMinutes": {
+      "type": "number"
+    },
+    "tools.web.fetch.enabled": {
+      "type": "boolean"
+    },
+    "tools.web.fetch.maxChars": {
+      "type": "integer"
+    },
+    "tools.web.fetch.maxRedirects": {
+      "type": "integer"
+    },
+    "tools.web.fetch.timeoutSeconds": {
+      "type": "integer"
+    },
+    "tools.web.fetch.userAgent": {
+      "type": "string"
+    },
+    "tools.web.search": {
+      "type": "object"
+    },
+    "tools.web.search.apiKey": {
+      "type": "string"
+    },
+    "tools.web.search.cacheTtlMinutes": {
+      "type": "number"
+    },
+    "tools.web.search.enabled": {
+      "type": "boolean"
+    },
+    "tools.web.search.maxResults": {
+      "type": "integer"
+    },
+    "tools.web.search.perplexity": {
+      "type": "object"
+    },
+    "tools.web.search.perplexity.apiKey": {
+      "type": "string"
+    },
+    "tools.web.search.perplexity.baseUrl": {
+      "type": "string"
+    },
+    "tools.web.search.perplexity.model": {
+      "type": "string"
+    },
+    "tools.web.search.provider": {
+      "type": "enum",
+      "values": [
+        "brave",
+        "perplexity"
+      ]
+    },
+    "tools.web.search.timeoutSeconds": {
+      "type": "integer"
+    },
+    "ui": {
+      "type": "object"
+    },
+    "ui.assistant": {
+      "type": "object"
+    },
+    "ui.assistant.avatar": {
+      "type": "string"
+    },
+    "ui.assistant.name": {
+      "type": "string"
+    },
+    "ui.seamColor": {
+      "type": "string"
+    },
+    "update": {
+      "type": "object"
+    },
+    "update.channel": {
+      "type": "enum",
+      "values": [
+        "stable",
+        "beta",
+        "dev"
+      ]
+    },
+    "update.checkOnStart": {
+      "type": "boolean"
+    },
+    "web": {
+      "type": "object"
+    },
+    "web.enabled": {
+      "type": "boolean"
+    },
+    "web.heartbeatSeconds": {
+      "type": "integer"
+    },
+    "web.reconnect": {
+      "type": "object"
+    },
+    "web.reconnect.factor": {
+      "type": "number"
+    },
+    "web.reconnect.initialMs": {
+      "type": "number"
+    },
+    "web.reconnect.jitter": {
+      "type": "number"
+    },
+    "web.reconnect.maxAttempts": {
+      "type": "integer"
+    },
+    "web.reconnect.maxMs": {
+      "type": "number"
+    },
+    "wizard": {
+      "type": "object"
+    },
+    "wizard.lastRunAt": {
+      "type": "string"
+    },
+    "wizard.lastRunCommand": {
+      "type": "string"
+    },
+    "wizard.lastRunCommit": {
+      "type": "string"
+    },
+    "wizard.lastRunMode": {
+      "type": "enum",
+      "values": [
+        "local",
+        "remote"
+      ]
+    },
+    "wizard.lastRunVersion": {
+      "type": "string"
+    }
+  },
+  "dynamicKeys": [
+    "agents.defaults.cliBackends",
+    "agents.defaults.cliBackends.*.env",
+    "agents.defaults.cliBackends.*.modelAliases",
+    "agents.defaults.memorySearch.remote.headers",
+    "agents.defaults.models",
+    "agents.defaults.models.*.params",
+    "agents.defaults.sandbox.docker.env",
+    "agents.defaults.sandbox.docker.ulimits",
+    "auth.cooldowns.billingBackoffHoursByProvider",
+    "auth.order",
+    "auth.profiles",
+    "browser.profiles",
+    "channels.bluebubbles.accounts",
+    "channels.bluebubbles.accounts.*.dms",
+    "channels.bluebubbles.accounts.*.groups",
+    "channels.bluebubbles.accounts.*.groups.*.toolsBySender",
+    "channels.bluebubbles.dms",
+    "channels.bluebubbles.groups",
+    "channels.bluebubbles.groups.*.toolsBySender",
+    "channels.discord.accounts",
+    "channels.discord.accounts.*.dms",
+    "channels.discord.accounts.*.guilds",
+    "channels.discord.accounts.*.guilds.*.channels",
+    "channels.discord.accounts.*.guilds.*.channels.*.toolsBySender",
+    "channels.discord.accounts.*.guilds.*.toolsBySender",
+    "channels.discord.dms",
+    "channels.discord.guilds",
+    "channels.discord.guilds.*.channels",
+    "channels.discord.guilds.*.channels.*.toolsBySender",
+    "channels.discord.guilds.*.toolsBySender",
+    "channels.googlechat.accounts",
+    "channels.googlechat.accounts.*.dms",
+    "channels.googlechat.accounts.*.groups",
+    "channels.googlechat.dms",
+    "channels.googlechat.groups",
+    "channels.imessage.accounts",
+    "channels.imessage.accounts.*.dms",
+    "channels.imessage.accounts.*.groups",
+    "channels.imessage.accounts.*.groups.*.toolsBySender",
+    "channels.imessage.dms",
+    "channels.imessage.groups",
+    "channels.imessage.groups.*.toolsBySender",
+    "channels.msteams.dms",
+    "channels.msteams.teams",
+    "channels.msteams.teams.*.channels",
+    "channels.msteams.teams.*.channels.*.toolsBySender",
+    "channels.msteams.teams.*.toolsBySender",
+    "channels.signal.accounts",
+    "channels.signal.accounts.*.dms",
+    "channels.signal.dms",
+    "channels.slack.accounts",
+    "channels.slack.accounts.*.channels",
+    "channels.slack.accounts.*.channels.*.toolsBySender",
+    "channels.slack.accounts.*.dms",
+    "channels.slack.channels",
+    "channels.slack.channels.*.toolsBySender",
+    "channels.slack.dms",
+    "channels.telegram.accounts",
+    "channels.telegram.accounts.*.dms",
+    "channels.telegram.accounts.*.groups",
+    "channels.telegram.accounts.*.groups.*.toolsBySender",
+    "channels.telegram.accounts.*.groups.*.topics",
+    "channels.telegram.dms",
+    "channels.telegram.groups",
+    "channels.telegram.groups.*.toolsBySender",
+    "channels.telegram.groups.*.topics",
+    "channels.whatsapp.accounts",
+    "channels.whatsapp.accounts.*.dms",
+    "channels.whatsapp.accounts.*.groups",
+    "channels.whatsapp.accounts.*.groups.*.toolsBySender",
+    "channels.whatsapp.dms",
+    "channels.whatsapp.groups",
+    "channels.whatsapp.groups.*.toolsBySender",
+    "diagnostics.otel.headers",
+    "env.vars",
+    "hooks.internal.entries",
+    "hooks.internal.entries.*.env",
+    "hooks.internal.installs",
+    "messages.inbound.byChannel",
+    "messages.queue.debounceMsByChannel",
+    "models.providers",
+    "models.providers.*.headers",
+    "plugins.entries",
+    "plugins.entries.*.config",
+    "plugins.installs",
+    "session.identityLinks",
+    "session.resetByChannel",
+    "skills.entries",
+    "skills.entries.*.config",
+    "skills.entries.*.env",
+    "talk.voiceAliases",
+    "tools.byProvider",
+    "tools.elevated.allowFrom",
+    "tools.media.audio.headers",
+    "tools.media.audio.providerOptions",
+    "tools.media.image.headers",
+    "tools.media.image.providerOptions",
+    "tools.media.video.headers",
+    "tools.media.video.providerOptions"
+  ],
+  "knownChannels": [
+    "bluebubbles",
+    "discord",
+    "googlechat",
+    "imessage",
+    "msteams",
+    "signal",
+    "slack",
+    "telegram",
+    "whatsapp"
+  ]
+}

--- a/nix/scripts/config-options-check.sh
+++ b/nix/scripts/config-options-check.sh
@@ -54,3 +54,17 @@ output_path="./generated-config-options.nix"
 ./node_modules/.bin/tsx ./generate-config-options.ts --repo . --out "$output_path"
 
 diff -u "$CONFIG_OPTIONS_GOLDEN" "$output_path"
+
+metadata_path="./openclaw-config-metadata.json"
+
+if [ ! -f "$metadata_path" ]; then
+  echo "Metadata file not generated: $metadata_path" >&2
+  exit 1
+fi
+
+if [ -z "${CONFIG_METADATA_GOLDEN:-}" ]; then
+  echo "CONFIG_METADATA_GOLDEN is not set" >&2
+  exit 1
+fi
+
+diff -u "$CONFIG_METADATA_GOLDEN" "$metadata_path"

--- a/scripts/update-pins.sh
+++ b/scripts/update-pins.sh
@@ -238,7 +238,7 @@ if git diff --quiet; then
 fi
 
 log "Committing updated pins"
-git add "$source_file" "$app_file" "$repo_root/nix/generated/openclaw-config-options.nix" "$repo_root/flake.lock"
+git add "$source_file" "$app_file" "$repo_root/nix/generated/openclaw-config-options.nix" "$repo_root/nix/generated/openclaw-config-metadata.json" "$repo_root/flake.lock"
 git commit -F - <<'EOF'
 🤖 codex: bump openclaw pins (no-issue)
 


### PR DESCRIPTION
## Summary

- Extend the config generator to emit a JSON metadata file (`openclaw-config-metadata.json`) alongside the Nix options, capturing valid paths, types, dynamic keys, and known channels from the upstream Zod schema
- Add a generic `providers.channels` system replacing the telegram-specific helpers, with backwards-compat aliases so existing `providers.telegram.*` config continues to work
- Auto-sync enum values (`thinkingDefault`, `queue.mode`) from the generated metadata instead of hardcoding them
- Add recursive `configOverrides` validation (key existence + type checking) and channel config validation against schema metadata, surfaced as standard home-manager assertion errors
- Update CI golden-file check and `update-pins.sh` to include the metadata file

## Test plan

- [x] `nix flake check --no-build` passes
- [x] `nix build .#checks.x86_64-linux.config-options` passes (via remote builder)
- [x] `nix eval` confirms metadata lookups return correct enum values
- [x] No references to removed `generatedConfigOptions` or `mkTelegramConfig` remain
- [ ] Verify existing `providers.telegram.*` configs still evaluate correctly (backwards compat)
- [ ] Verify invalid `configOverrides` keys produce assertion errors
- [ ] Verify unknown channel names in `providers.channels` produce assertion errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)