### PR TITLE
fix: set force=true on config home.file to prevent clobber errors

### DIFF
--- a/nix/modules/home-manager/openclaw/config.nix
+++ b/nix/modules/home-manager/openclaw/config.nix
@@ -125,7 +125,7 @@ let
   in {
     homeFile = {
       name = openclawLib.toRelative inst.configPath;
-      value = { text = configJson; };
+      value = { text = configJson; force = true; };
     };
     configFile = configFile;
     configPath = inst.configPath;


### PR DESCRIPTION
## Summary

- Set `force = true` on the `home.file` entry for `openclaw.json` so home-manager overwrites it unconditionally
- Fixes `home-manager switch` failing with "Existing file would be clobbered" after the gateway replaces the nix store symlink with a regular file

## Root cause

The gateway's `applyPluginAutoEnable` runs on startup and calls `writeConfigFile()` even when `OPENCLAW_NIX_MODE=1` is set. This replaces the read-only nix store symlink with a regular file. On the next `home-manager switch`, the `checkLinkTargets` step fails because it refuses to overwrite an unmanaged regular file.

The `isNixMode` guard exists for legacy config migration but is missing from the plugin auto-enable code path. This PR works around that by telling home-manager it's safe to overwrite.

## Test plan

- [x] Verified existing checks (`openclaw-config-validity`, `openclaw-hm-activation`) are unaffected — they access `.text`, not `force`
- [ ] Run `home-manager switch` after gateway has replaced the symlink — should succeed without `-b backup`

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)