### PR TITLE
feat: add aarch64-linux to supported systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
       systems = [
         "x86_64-linux"
         "aarch64-darwin"
+        "aarch64-linux"
       ];
     in
     flake-utils.lib.eachSystem systems (


### PR DESCRIPTION
## Summary

Adds `aarch64-linux` to the supported systems list in `flake.nix`.

## Motivation

ARM64 Linux is increasingly common for hosting:
- Oracle Cloud free tier (Ampere A1)
- Hetzner Cloud CAX instances
- Raspberry Pi
- AWS Graviton

The OpenClaw build is pure Node.js/pnpm with no platform-specific native code barriers.

## Testing

- Successfully built `nix build .#packages.aarch64-linux.openclaw-gateway` on NixOS aarch64-linux (Hetzner CAX41, 16 vCPU ARM64)
- The pnpm deps fetch and Node.js compilation complete without issues

## Changes

One-line change: added `"aarch64-linux"` to the `systems` list in `flake.nix`.