### PR TITLE
Add externalConfig option to support external openclaw.json files

### DIFF
--- a/nix/modules/home-manager/openclaw/options-instance.nix
+++ b/nix/modules/home-manager/openclaw/options-instance.nix
@@ -91,6 +91,12 @@
       description = "OpenClaw config (schema-typed).";
     };
 
+    externalConfig = lib.mkOption {
+      type = lib.types.nullOr (lib.types.either lib.types.path lib.types.str);
+      default = null;
+      description = "Path to an external openclaw.json file, or its content as a string (use builtins.readFile to read from a file). When set, this file will be used directly instead of generating config from the 'config' option.";
+    };
+
     launchd.enable = lib.mkOption {
       type = lib.types.bool;
       default = true;

--- a/nix/modules/home-manager/openclaw/options-instance.nix
+++ b/nix/modules/home-manager/openclaw/options-instance.nix
@@ -92,9 +92,13 @@
     };
 
     externalConfig = lib.mkOption {
-      type = lib.types.nullOr (lib.types.either lib.types.path lib.types.str);
+      type = lib.types.nullOr lib.types.str;
       default = null;
-      description = "Path to an external openclaw.json file, or its content as a string (use builtins.readFile to read from a file). When set, this file will be used directly instead of generating config from the 'config' option.";
+      description = ''
+        External openclaw.json content as a string (use builtins.readFile to read from a file).
+        When set, this file will be used directly instead of generating config from the 'config' option.
+        Note: Cannot be used together with 'config' - use one or the other.
+      '';
     };
 
     launchd.enable = lib.mkOption {


### PR DESCRIPTION
### Summary

This PR adds a new `externalConfig` option to the nix-openclaw home-manager module, allowing users to specify an external `openclaw.json` file instead of generating config solely from Nix options.

### Motivation

The nix-openclaw module generates `openclaw.json` from Nix code using schema-typed options. However, some channels (like Matrix) are not yet supported in the generated options. Users who need these unsupported channels must either:

1. Manually maintain `openclaw.json` outside of home-manager (risk of being overwritten)
2. Fork the module to add missing options

This PR provides a third option: use an external `openclaw.json` file directly while still benefiting from home-manager's declarative configuration.

### Changes

- Add `externalConfig` option in `options-instance.nix`:
  - Type: `nullOr str`
  - Accepts JSON content as a string (use `builtins.readFile` to read from file)
  
- Update `config.nix` to:
  - Check if `externalConfig` is set
  - If set, use the external config directly
  - Add validation to prevent using both `config` and `externalConfig` simultaneously

### Usage Example

```nix
programs.openclaw = {
  enable = true;
  instances.default = {
    # Use external config file
    externalConfig = builtins.toJSON (builtins.fromJSON (builtins.readFile ./openclaw.json));
  };
};
```

### Backwards Compatibility

This change is fully backwards compatible. Existing configurations using `config = { ... }` will continue to work without any modifications.