### PR TITLE
Include assets/chrome-extension in gateway package

### DIFF
--- a/nix/scripts/check-package-contents.sh
+++ b/nix/scripts/check-package-contents.sh
@@ -15,6 +15,8 @@ require_path() {
   fi
 }
 
+require_path "${root}/assets/chrome-extension"
+require_path "${root}/assets/chrome-extension/manifest.json"
 require_path "${root}/extensions"
 require_path "${root}/extensions/memory-core"
 require_path "${root}/docs/reference/templates"

--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -44,6 +44,9 @@ log_step "move build outputs" mv dist node_modules package.json "$out/lib/opencl
 if [ -d extensions ]; then
   log_step "copy extensions" cp -r extensions "$out/lib/openclaw/"
 fi
+if [ -d assets ]; then
+  log_step "copy assets" cp -r assets "$out/lib/openclaw/"
+fi
 
 if [ -d docs/reference/templates ]; then
   mkdir -p "$out/lib/openclaw/docs/reference"


### PR DESCRIPTION
## Summary

- Copy the `assets/` directory to the gateway output alongside `extensions/` during install
- Add package-contents check for `assets/chrome-extension/manifest.json`

## Problem

`openclaw browser extension install` fails with:

```
Error: Bundled Chrome extension is missing. Reinstall OpenClaw and try again.
```

The runtime code (`resolveBundledExtensionRootDir` in `browser-cli-extension.ts`) walks up from `dist/` looking for `assets/chrome-extension/manifest.json`. The `assets/` directory exists in the source tree but `gateway-install.sh` doesn't copy it to `$out/lib/openclaw/`.

## Workaround

Users can work around this with an overlay:

```nix
(final: prev: let
  openclaw-gateway-patched = prev.openclaw-gateway.overrideAttrs (old: {
    installPhase = ''
      ${old.installPhase}
      if [ -d "$src/assets" ]; then
        cp -r "$src/assets" "$out/lib/openclaw/"
      fi
    '';
  });
in {
  openclaw-gateway = openclaw-gateway-patched;
  openclaw = prev.openclaw.override { openclaw-gateway = openclaw-gateway-patched; };
})
```

## Test plan

- [ ] `nix build .#openclaw-gateway` succeeds
- [ ] `nix flake check` passes (including `package-contents` check)
- [ ] `openclaw browser extension install` works with the built package