### PR TITLE
Exclude bird from default tools

### DIFF
--- a/nix/tools/extended.nix
+++ b/nix/tools/extended.nix
@@ -37,7 +37,10 @@ let
   ];
 
   pluginCatalog = import ../modules/home-manager/openclaw/plugin-catalog.nix;
-  bundledToolNames = lib.unique (map (plugin: plugin.tool) (builtins.attrValues pluginCatalog));
+  bundledToolNames = lib.unique (
+    builtins.filter (name: name != "bird")
+      (map (plugin: plugin.tool) (builtins.attrValues pluginCatalog))
+  );
 
   extraNames = [
     "go"


### PR DESCRIPTION
## Summary
- Remove `bird` from the default tool list so builds don’t fail when the upstream release asset is unavailable.
- Keeps `bird` available via explicit tool overrides.
## Context
The `bird` repo release asset is now 404 (repo private), which breaks nix-openclaw builds on macOS.