### PR TITLE
Bump to OpenClaw v2026.2.25, fix rolldown sandbox shim, exclude deleted bird tool

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,9 @@
           pkgs = pkgs;
           sourceInfo = sourceInfoStable;
           steipetePkgs = steipetePkgs;
+          # bird: upstream repo steipete/bird deleted, release assets 404.
+          # https://github.com/openclaw/nix-steipete-tools/issues/6
+          excludeToolNames = [ "bird" ];
         };
       in
       {

--- a/nix/generated/openclaw-config-options.nix
+++ b/nix/generated/openclaw-config-options.nix
@@ -1,4 +1,4 @@
-# Generated from upstream OpenClaw schema at rev 819cec3c406a45d231057e37ace2f68cb6769255. DO NOT EDIT.
+# Generated from upstream OpenClaw schema at rev 4b5d4a4c660d05e4bd73f0e11123e68fd9664432. DO NOT EDIT.
 # Generator: nix/scripts/generate-config-options.ts
 { lib }:
 let
@@ -367,6 +367,10 @@ in
             default = null;
           };
         }; });
+          default = null;
+        };
+        directPolicy = lib.mkOption {
+          type = t.nullOr (t.oneOf [ (t.enum [ "allow" ]) (t.enum [ "block" ]) ]);
           default = null;
         };
         every = lib.mkOption {
@@ -1067,6 +1071,10 @@ in
             default = null;
           };
         }; });
+          default = null;
+        };
+        directPolicy = lib.mkOption {
+          type = t.nullOr (t.oneOf [ (t.enum [ "allow" ]) (t.enum [ "block" ]) ]);
           default = null;
         };
         every = lib.mkOption {
@@ -9915,6 +9923,10 @@ in
         default = null;
       };
     }; });
+      default = null;
+    };
+    parentForkMaxTokens = lib.mkOption {
+      type = t.nullOr (t.int);
       default = null;
     };
     reset = lib.mkOption {

--- a/nix/generated/openclaw-config-options.nix
+++ b/nix/generated/openclaw-config-options.nix
@@ -1,4 +1,4 @@
-# Generated from upstream OpenClaw schema at rev 0fe8f07e0ed9381ed6acb51de7623d991274a18b. DO NOT EDIT.
+# Generated from upstream OpenClaw schema at rev a54dc7fe80fc02e2a02e6901668a468fcb0cf8b4. DO NOT EDIT.
 # Generator: nix/scripts/generate-config-options.ts
 { lib }:
 let
@@ -492,7 +492,7 @@ in
           default = null;
         };
         fallback = lib.mkOption {
-          type = t.nullOr (t.oneOf [ (t.enum [ "openai" ]) (t.enum [ "gemini" ]) (t.enum [ "local" ]) (t.enum [ "voyage" ]) (t.enum [ "none" ]) ]);
+          type = t.nullOr (t.oneOf [ (t.enum [ "openai" ]) (t.enum [ "gemini" ]) (t.enum [ "local" ]) (t.enum [ "voyage" ]) (t.enum [ "mistral" ]) (t.enum [ "none" ]) ]);
           default = null;
         };
         local = lib.mkOption {
@@ -513,7 +513,7 @@ in
           default = null;
         };
         provider = lib.mkOption {
-          type = t.nullOr (t.oneOf [ (t.enum [ "openai" ]) (t.enum [ "local" ]) (t.enum [ "gemini" ]) (t.enum [ "voyage" ]) ]);
+          type = t.nullOr (t.oneOf [ (t.enum [ "openai" ]) (t.enum [ "local" ]) (t.enum [ "gemini" ]) (t.enum [ "voyage" ]) (t.enum [ "mistral" ]) ]);
           default = null;
         };
         query = lib.mkOption {
@@ -747,6 +747,10 @@ in
             type = t.nullOr (t.int);
             default = null;
           };
+          cdpSourceRange = lib.mkOption {
+            type = t.nullOr (t.str);
+            default = null;
+          };
           containerPrefix = lib.mkOption {
             type = t.nullOr (t.str);
             default = null;
@@ -764,6 +768,10 @@ in
             default = null;
           };
           image = lib.mkOption {
+            type = t.nullOr (t.str);
+            default = null;
+          };
+          network = lib.mkOption {
             type = t.nullOr (t.str);
             default = null;
           };
@@ -918,6 +926,10 @@ in
       };
       subagents = lib.mkOption {
         type = t.nullOr (t.submodule { options = {
+        announceTimeoutMs = lib.mkOption {
+          type = t.nullOr (t.int);
+          default = null;
+        };
         archiveAfterMinutes = lib.mkOption {
           type = t.nullOr (t.int);
           default = null;
@@ -1163,7 +1175,7 @@ in
           default = null;
         };
         fallback = lib.mkOption {
-          type = t.nullOr (t.oneOf [ (t.enum [ "openai" ]) (t.enum [ "gemini" ]) (t.enum [ "local" ]) (t.enum [ "voyage" ]) (t.enum [ "none" ]) ]);
+          type = t.nullOr (t.oneOf [ (t.enum [ "openai" ]) (t.enum [ "gemini" ]) (t.enum [ "local" ]) (t.enum [ "voyage" ]) (t.enum [ "mistral" ]) (t.enum [ "none" ]) ]);
           default = null;
         };
         local = lib.mkOption {
@@ -1184,7 +1196,7 @@ in
           default = null;
         };
         provider = lib.mkOption {
-          type = t.nullOr (t.oneOf [ (t.enum [ "openai" ]) (t.enum [ "local" ]) (t.enum [ "gemini" ]) (t.enum [ "voyage" ]) ]);
+          type = t.nullOr (t.oneOf [ (t.enum [ "openai" ]) (t.enum [ "local" ]) (t.enum [ "gemini" ]) (t.enum [ "voyage" ]) (t.enum [ "mistral" ]) ]);
           default = null;
         };
         query = lib.mkOption {
@@ -1401,6 +1413,10 @@ in
             type = t.nullOr (t.int);
             default = null;
           };
+          cdpSourceRange = lib.mkOption {
+            type = t.nullOr (t.str);
+            default = null;
+          };
           containerPrefix = lib.mkOption {
             type = t.nullOr (t.str);
             default = null;
@@ -1418,6 +1434,10 @@ in
             default = null;
           };
           image = lib.mkOption {
+            type = t.nullOr (t.str);
+            default = null;
+          };
+          network = lib.mkOption {
             type = t.nullOr (t.str);
             default = null;
           };
@@ -1699,6 +1719,31 @@ in
             type = t.nullOr (t.listOf (t.str));
             default = null;
           };
+          safeBinProfiles = lib.mkOption {
+            type = t.nullOr (t.attrsOf (t.submodule { options = {
+            allowedValueFlags = lib.mkOption {
+              type = t.nullOr (t.listOf (t.str));
+              default = null;
+            };
+            deniedFlags = lib.mkOption {
+              type = t.nullOr (t.listOf (t.str));
+              default = null;
+            };
+            maxPositional = lib.mkOption {
+              type = t.nullOr (t.int);
+              default = null;
+            };
+            minPositional = lib.mkOption {
+              type = t.nullOr (t.int);
+              default = null;
+            };
+          }; }));
+            default = null;
+          };
+          safeBinTrustedDirs = lib.mkOption {
+            type = t.nullOr (t.listOf (t.str));
+            default = null;
+          };
           safeBins = lib.mkOption {
             type = t.nullOr (t.listOf (t.str));
             default = null;
@@ -1919,6 +1964,10 @@ in
     type = t.nullOr (t.listOf (t.submodule { options = {
     agentId = lib.mkOption {
       type = t.str;
+    };
+    comment = lib.mkOption {
+      type = t.nullOr (t.str);
+      default = null;
     };
     match = lib.mkOption {
       type = t.submodule { options = {
@@ -3030,8 +3079,29 @@ in
           type = t.nullOr (t.enum [ "partial" "block" "off" ]);
           default = null;
         };
+        streaming = lib.mkOption {
+          type = t.nullOr (t.oneOf [ (t.bool) (t.enum [ "off" "partial" "block" "progress" ]) ]);
+          default = null;
+        };
         textChunkLimit = lib.mkOption {
           type = t.nullOr (t.int);
+          default = null;
+        };
+        threadBindings = lib.mkOption {
+          type = t.nullOr (t.submodule { options = {
+          enabled = lib.mkOption {
+            type = t.nullOr (t.bool);
+            default = null;
+          };
+          spawnSubagentSessions = lib.mkOption {
+            type = t.nullOr (t.bool);
+            default = null;
+          };
+          ttlHours = lib.mkOption {
+            type = t.nullOr (t.number);
+            default = null;
+          };
+        }; });
           default = null;
         };
         token = lib.mkOption {
@@ -3772,8 +3842,29 @@ in
         type = t.nullOr (t.enum [ "partial" "block" "off" ]);
         default = null;
       };
+      streaming = lib.mkOption {
+        type = t.nullOr (t.oneOf [ (t.bool) (t.enum [ "off" "partial" "block" "progress" ]) ]);
+        default = null;
+      };
       textChunkLimit = lib.mkOption {
         type = t.nullOr (t.int);
+        default = null;
+      };
+      threadBindings = lib.mkOption {
+        type = t.nullOr (t.submodule { options = {
+        enabled = lib.mkOption {
+          type = t.nullOr (t.bool);
+          default = null;
+        };
+        spawnSubagentSessions = lib.mkOption {
+          type = t.nullOr (t.bool);
+          default = null;
+        };
+        ttlHours = lib.mkOption {
+          type = t.nullOr (t.number);
+          default = null;
+        };
+      }; });
         default = null;
       };
       token = lib.mkOption {
@@ -6179,6 +6270,10 @@ in
           type = t.nullOr (t.str);
           default = null;
         };
+        nativeStreaming = lib.mkOption {
+          type = t.nullOr (t.bool);
+          default = null;
+        };
         reactionAllowlist = lib.mkOption {
           type = t.nullOr (t.listOf (t.oneOf [ (t.str) (t.number) ]));
           default = null;
@@ -6241,8 +6336,12 @@ in
         }; });
           default = null;
         };
+        streamMode = lib.mkOption {
+          type = t.nullOr (t.enum [ "replace" "status_final" "append" ]);
+          default = null;
+        };
         streaming = lib.mkOption {
-          type = t.nullOr (t.bool);
+          type = t.nullOr (t.oneOf [ (t.bool) (t.enum [ "off" "partial" "block" "progress" ]) ]);
           default = null;
         };
         textChunkLimit = lib.mkOption {
@@ -6551,6 +6650,10 @@ in
         type = t.nullOr (t.str);
         default = null;
       };
+      nativeStreaming = lib.mkOption {
+        type = t.nullOr (t.bool);
+        default = null;
+      };
       reactionAllowlist = lib.mkOption {
         type = t.nullOr (t.listOf (t.oneOf [ (t.str) (t.number) ]));
         default = null;
@@ -6613,8 +6716,12 @@ in
       }; });
         default = null;
       };
+      streamMode = lib.mkOption {
+        type = t.nullOr (t.enum [ "replace" "status_final" "append" ]);
+        default = null;
+      };
       streaming = lib.mkOption {
-        type = t.nullOr (t.bool);
+        type = t.nullOr (t.oneOf [ (t.bool) (t.enum [ "off" "partial" "block" "progress" ]) ]);
         default = null;
       };
       textChunkLimit = lib.mkOption {
@@ -6942,6 +7049,10 @@ in
             type = t.nullOr (t.bool);
             default = null;
           };
+          dnsResultOrder = lib.mkOption {
+            type = t.nullOr (t.enum [ "ipv4first" "verbatim" ]);
+            default = null;
+          };
         }; });
           default = null;
         };
@@ -6990,6 +7101,10 @@ in
           type = t.nullOr (t.enum [ "off" "partial" "block" ]);
           default = null;
         };
+        streaming = lib.mkOption {
+          type = t.nullOr (t.oneOf [ (t.bool) (t.enum [ "off" "partial" "block" "progress" ]) ]);
+          default = null;
+        };
         textChunkLimit = lib.mkOption {
           type = t.nullOr (t.int);
           default = null;
@@ -7008,6 +7123,10 @@ in
         };
         webhookPath = lib.mkOption {
           type = t.nullOr (t.str);
+          default = null;
+        };
+        webhookPort = lib.mkOption {
+          type = t.nullOr (t.int);
           default = null;
         };
         webhookSecret = lib.mkOption {
@@ -7306,6 +7425,10 @@ in
           type = t.nullOr (t.bool);
           default = null;
         };
+        dnsResultOrder = lib.mkOption {
+          type = t.nullOr (t.enum [ "ipv4first" "verbatim" ]);
+          default = null;
+        };
       }; });
         default = null;
       };
@@ -7354,6 +7477,10 @@ in
         type = t.nullOr (t.enum [ "off" "partial" "block" ]);
         default = null;
       };
+      streaming = lib.mkOption {
+        type = t.nullOr (t.oneOf [ (t.bool) (t.enum [ "off" "partial" "block" "progress" ]) ]);
+        default = null;
+      };
       textChunkLimit = lib.mkOption {
         type = t.nullOr (t.int);
         default = null;
@@ -7372,6 +7499,10 @@ in
       };
       webhookPath = lib.mkOption {
         type = t.nullOr (t.str);
+        default = null;
+      };
+      webhookPort = lib.mkOption {
+        type = t.nullOr (t.int);
         default = null;
       };
       webhookSecret = lib.mkOption {
@@ -7830,6 +7961,14 @@ in
       type = t.nullOr (t.listOf (t.oneOf [ (t.str) (t.number) ]));
       default = null;
     };
+    ownerDisplay = lib.mkOption {
+      type = t.nullOr (t.enum [ "raw" "hash" ]);
+      default = null;
+    };
+    ownerDisplaySecret = lib.mkOption {
+      type = t.nullOr (t.str);
+      default = null;
+    };
     restart = lib.mkOption {
       type = t.nullOr (t.bool);
       default = null;
@@ -8009,6 +8148,10 @@ in
 
   gateway = lib.mkOption {
     type = t.nullOr (t.submodule { options = {
+    allowRealIpFallback = lib.mkOption {
+      type = t.nullOr (t.bool);
+      default = null;
+    };
     auth = lib.mkOption {
       type = t.nullOr (t.submodule { options = {
       allowTailscale = lib.mkOption {
@@ -8705,6 +8848,10 @@ in
       type = t.nullOr (t.oneOf [ (t.enum [ "silent" ]) (t.enum [ "fatal" ]) (t.enum [ "error" ]) (t.enum [ "warn" ]) (t.enum [ "info" ]) (t.enum [ "debug" ]) (t.enum [ "trace" ]) ]);
       default = null;
     };
+    maxFileBytes = lib.mkOption {
+      type = t.nullOr (t.int);
+      default = null;
+    };
     redactPatterns = lib.mkOption {
       type = t.nullOr (t.listOf (t.str));
       default = null;
@@ -8763,6 +8910,23 @@ in
         };
         timeoutMs = lib.mkOption {
           type = t.nullOr (t.int);
+          default = null;
+        };
+      }; });
+        default = null;
+      };
+      mcporter = lib.mkOption {
+        type = t.nullOr (t.submodule { options = {
+        enabled = lib.mkOption {
+          type = t.nullOr (t.bool);
+          default = null;
+        };
+        serverName = lib.mkOption {
+          type = t.nullOr (t.str);
+          default = null;
+        };
+        startDaemon = lib.mkOption {
+          type = t.nullOr (t.bool);
           default = null;
         };
       }; });
@@ -9792,6 +9956,19 @@ in
       type = t.nullOr (t.str);
       default = null;
     };
+    threadBindings = lib.mkOption {
+      type = t.nullOr (t.submodule { options = {
+      enabled = lib.mkOption {
+        type = t.nullOr (t.bool);
+        default = null;
+      };
+      ttlHours = lib.mkOption {
+        type = t.nullOr (t.number);
+        default = null;
+      };
+    }; });
+      default = null;
+    };
     typingIntervalSeconds = lib.mkOption {
       type = t.nullOr (t.int);
       default = null;
@@ -10029,6 +10206,31 @@ in
         default = null;
       };
       pathPrepend = lib.mkOption {
+        type = t.nullOr (t.listOf (t.str));
+        default = null;
+      };
+      safeBinProfiles = lib.mkOption {
+        type = t.nullOr (t.attrsOf (t.submodule { options = {
+        allowedValueFlags = lib.mkOption {
+          type = t.nullOr (t.listOf (t.str));
+          default = null;
+        };
+        deniedFlags = lib.mkOption {
+          type = t.nullOr (t.listOf (t.str));
+          default = null;
+        };
+        maxPositional = lib.mkOption {
+          type = t.nullOr (t.int);
+          default = null;
+        };
+        minPositional = lib.mkOption {
+          type = t.nullOr (t.int);
+          default = null;
+        };
+      }; }));
+        default = null;
+      };
+      safeBinTrustedDirs = lib.mkOption {
         type = t.nullOr (t.listOf (t.str));
         default = null;
       };
@@ -11100,6 +11302,27 @@ in
 
   update = lib.mkOption {
     type = t.nullOr (t.submodule { options = {
+    auto = lib.mkOption {
+      type = t.nullOr (t.submodule { options = {
+      betaCheckIntervalHours = lib.mkOption {
+        type = t.nullOr (t.number);
+        default = null;
+      };
+      enabled = lib.mkOption {
+        type = t.nullOr (t.bool);
+        default = null;
+      };
+      stableDelayHours = lib.mkOption {
+        type = t.nullOr (t.number);
+        default = null;
+      };
+      stableJitterHours = lib.mkOption {
+        type = t.nullOr (t.number);
+        default = null;
+      };
+    }; });
+      default = null;
+    };
     channel = lib.mkOption {
       type = t.nullOr (t.oneOf [ (t.enum [ "stable" ]) (t.enum [ "beta" ]) (t.enum [ "dev" ]) ]);
       default = null;

--- a/nix/generated/openclaw-config-options.nix
+++ b/nix/generated/openclaw-config-options.nix
@@ -1,4 +1,4 @@
-# Generated from upstream OpenClaw schema at rev b817600533129771ace2801d7c05901c7f850fb8. DO NOT EDIT.
+# Generated from upstream OpenClaw schema at rev 819cec3c406a45d231057e37ace2f68cb6769255. DO NOT EDIT.
 # Generator: nix/scripts/generate-config-options.ts
 { lib }:
 let
@@ -808,6 +808,10 @@ in
             type = t.nullOr (t.number);
             default = null;
           };
+          dangerouslyAllowContainerNamespaceJoin = lib.mkOption {
+            type = t.nullOr (t.bool);
+            default = null;
+          };
           dangerouslyAllowExternalBindSources = lib.mkOption {
             type = t.nullOr (t.bool);
             default = null;
@@ -1484,6 +1488,10 @@ in
           };
           cpus = lib.mkOption {
             type = t.nullOr (t.number);
+            default = null;
+          };
+          dangerouslyAllowContainerNamespaceJoin = lib.mkOption {
+            type = t.nullOr (t.bool);
             default = null;
           };
           dangerouslyAllowExternalBindSources = lib.mkOption {
@@ -3163,6 +3171,14 @@ in
           }; }));
             default = null;
           };
+          daveEncryption = lib.mkOption {
+            type = t.nullOr (t.bool);
+            default = null;
+          };
+          decryptionFailureTolerance = lib.mkOption {
+            type = t.nullOr (t.int);
+            default = null;
+          };
           enabled = lib.mkOption {
             type = t.nullOr (t.bool);
             default = null;
@@ -3928,6 +3944,14 @@ in
             type = t.str;
           };
         }; }));
+          default = null;
+        };
+        daveEncryption = lib.mkOption {
+          type = t.nullOr (t.bool);
+          default = null;
+        };
+        decryptionFailureTolerance = lib.mkOption {
+          type = t.nullOr (t.int);
           default = null;
         };
         enabled = lib.mkOption {
@@ -9527,7 +9551,7 @@ in
   meta = lib.mkOption {
     type = t.nullOr (t.submodule { options = {
     lastTouchedAt = lib.mkOption {
-      type = t.nullOr (t.str);
+      type = t.nullOr (t.oneOf [ (t.str) (t.anything) ]);
       default = null;
     };
     lastTouchedVersion = lib.mkOption {
@@ -10177,6 +10201,35 @@ in
     };
     outputFormat = lib.mkOption {
       type = t.nullOr (t.str);
+      default = null;
+    };
+    provider = lib.mkOption {
+      type = t.nullOr (t.str);
+      default = null;
+    };
+    providers = lib.mkOption {
+      type = t.nullOr (t.attrsOf (t.submodule { options = {
+      apiKey = lib.mkOption {
+        type = t.nullOr (t.str);
+        default = null;
+      };
+      modelId = lib.mkOption {
+        type = t.nullOr (t.str);
+        default = null;
+      };
+      outputFormat = lib.mkOption {
+        type = t.nullOr (t.str);
+        default = null;
+      };
+      voiceAliases = lib.mkOption {
+        type = t.nullOr (t.attrsOf (t.str));
+        default = null;
+      };
+      voiceId = lib.mkOption {
+        type = t.nullOr (t.str);
+        default = null;
+      };
+    }; }));
       default = null;
     };
     voiceAliases = lib.mkOption {

--- a/nix/generated/openclaw-config-options.nix
+++ b/nix/generated/openclaw-config-options.nix
@@ -1,4 +1,4 @@
-# Generated from upstream OpenClaw schema at rev a54dc7fe80fc02e2a02e6901668a468fcb0cf8b4. DO NOT EDIT.
+# Generated from upstream OpenClaw schema at rev b817600533129771ace2801d7c05901c7f850fb8. DO NOT EDIT.
 # Generator: nix/scripts/generate-config-options.ts
 { lib }:
 let
@@ -426,7 +426,7 @@ in
         default = null;
       };
       imageModel = lib.mkOption {
-        type = t.nullOr (t.submodule { options = {
+        type = t.nullOr (t.oneOf [ (t.str) (t.submodule { options = {
         fallbacks = lib.mkOption {
           type = t.nullOr (t.listOf (t.str));
           default = null;
@@ -435,7 +435,7 @@ in
           type = t.nullOr (t.str);
           default = null;
         };
-      }; });
+      }; }) ]);
         default = null;
       };
       maxConcurrent = lib.mkOption {
@@ -690,7 +690,7 @@ in
         default = null;
       };
       model = lib.mkOption {
-        type = t.nullOr (t.submodule { options = {
+        type = t.nullOr (t.oneOf [ (t.str) (t.submodule { options = {
         fallbacks = lib.mkOption {
           type = t.nullOr (t.listOf (t.str));
           default = null;
@@ -699,7 +699,7 @@ in
           type = t.nullOr (t.str);
           default = null;
         };
-      }; });
+      }; }) ]);
         default = null;
       };
       models = lib.mkOption {
@@ -806,6 +806,14 @@ in
           };
           cpus = lib.mkOption {
             type = t.nullOr (t.number);
+            default = null;
+          };
+          dangerouslyAllowExternalBindSources = lib.mkOption {
+            type = t.nullOr (t.bool);
+            default = null;
+          };
+          dangerouslyAllowReservedContainerTargets = lib.mkOption {
+            type = t.nullOr (t.bool);
             default = null;
           };
           dns = lib.mkOption {
@@ -959,6 +967,10 @@ in
             default = null;
           };
         }; }) ]);
+          default = null;
+        };
+        runTimeoutSeconds = lib.mkOption {
+          type = t.nullOr (t.int);
           default = null;
         };
         thinking = lib.mkOption {
@@ -1472,6 +1484,14 @@ in
           };
           cpus = lib.mkOption {
             type = t.nullOr (t.number);
+            default = null;
+          };
+          dangerouslyAllowExternalBindSources = lib.mkOption {
+            type = t.nullOr (t.bool);
+            default = null;
+          };
+          dangerouslyAllowReservedContainerTargets = lib.mkOption {
+            type = t.nullOr (t.bool);
             default = null;
           };
           dns = lib.mkOption {
@@ -2102,6 +2122,10 @@ in
         type = t.nullOr (t.listOf (t.str));
         default = null;
       };
+      dangerouslyAllowPrivateNetwork = lib.mkOption {
+        type = t.nullOr (t.bool);
+        default = null;
+      };
       hostnameAllowlist = lib.mkOption {
         type = t.nullOr (t.listOf (t.str));
         default = null;
@@ -2724,6 +2748,10 @@ in
           default = null;
         };
         configWrites = lib.mkOption {
+          type = t.nullOr (t.bool);
+          default = null;
+        };
+        dangerouslyAllowNameMatching = lib.mkOption {
           type = t.nullOr (t.bool);
           default = null;
         };
@@ -3490,6 +3518,10 @@ in
         type = t.nullOr (t.bool);
         default = null;
       };
+      dangerouslyAllowNameMatching = lib.mkOption {
+        type = t.nullOr (t.bool);
+        default = null;
+      };
       defaultTo = lib.mkOption {
         type = t.nullOr (t.str);
         default = null;
@@ -4164,6 +4196,10 @@ in
           type = t.nullOr (t.bool);
           default = null;
         };
+        dangerouslyAllowNameMatching = lib.mkOption {
+          type = t.nullOr (t.bool);
+          default = null;
+        };
         defaultTo = lib.mkOption {
           type = t.nullOr (t.str);
           default = null;
@@ -4345,6 +4381,10 @@ in
         default = null;
       };
       configWrites = lib.mkOption {
+        type = t.nullOr (t.bool);
+        default = null;
+      };
+      dangerouslyAllowNameMatching = lib.mkOption {
         type = t.nullOr (t.bool);
         default = null;
       };
@@ -5415,6 +5455,10 @@ in
         type = t.nullOr (t.bool);
         default = null;
       };
+      dangerouslyAllowNameMatching = lib.mkOption {
+        type = t.nullOr (t.bool);
+        default = null;
+      };
       defaultTo = lib.mkOption {
         type = t.nullOr (t.str);
         default = null;
@@ -6170,6 +6214,10 @@ in
           type = t.nullOr (t.bool);
           default = null;
         };
+        dangerouslyAllowNameMatching = lib.mkOption {
+          type = t.nullOr (t.bool);
+          default = null;
+        };
         defaultTo = lib.mkOption {
           type = t.nullOr (t.str);
           default = null;
@@ -6547,6 +6595,10 @@ in
         default = null;
       };
       configWrites = lib.mkOption {
+        type = t.nullOr (t.bool);
+        default = null;
+      };
+      dangerouslyAllowNameMatching = lib.mkOption {
         type = t.nullOr (t.bool);
         default = null;
       };
@@ -7815,6 +7867,10 @@ in
       }; }));
         default = null;
       };
+      enabled = lib.mkOption {
+        type = t.nullOr (t.bool);
+        default = null;
+      };
       groupAllowFrom = lib.mkOption {
         type = t.nullOr (t.listOf (t.str));
         default = null;
@@ -7993,6 +8049,19 @@ in
     };
     maxConcurrentRuns = lib.mkOption {
       type = t.nullOr (t.int);
+      default = null;
+    };
+    runLog = lib.mkOption {
+      type = t.nullOr (t.submodule { options = {
+      keepLines = lib.mkOption {
+        type = t.nullOr (t.int);
+        default = null;
+      };
+      maxBytes = lib.mkOption {
+        type = t.nullOr (t.oneOf [ (t.str) (t.number) ]);
+        default = null;
+      };
+    }; });
       default = null;
     };
     sessionRetention = lib.mkOption {
@@ -8232,6 +8301,10 @@ in
         type = t.nullOr (t.str);
         default = null;
       };
+      dangerouslyAllowHostHeaderOriginFallback = lib.mkOption {
+        type = t.nullOr (t.bool);
+        default = null;
+      };
       dangerouslyDisableDeviceAuth = lib.mkOption {
         type = t.nullOr (t.bool);
         default = null;
@@ -8358,6 +8431,15 @@ in
             default = null;
           };
         }; });
+          default = null;
+        };
+      }; });
+        default = null;
+      };
+      securityHeaders = lib.mkOption {
+        type = t.nullOr (t.submodule { options = {
+        strictTransportSecurity = lib.mkOption {
+          type = t.nullOr (t.oneOf [ (t.str) (t.enum [ false ]) ]);
           default = null;
         };
       }; });
@@ -9776,6 +9858,14 @@ in
     };
     maintenance = lib.mkOption {
       type = t.nullOr (t.submodule { options = {
+      highWaterBytes = lib.mkOption {
+        type = t.nullOr (t.oneOf [ (t.str) (t.number) ]);
+        default = null;
+      };
+      maxDiskBytes = lib.mkOption {
+        type = t.nullOr (t.oneOf [ (t.str) (t.number) ]);
+        default = null;
+      };
       maxEntries = lib.mkOption {
         type = t.nullOr (t.int);
         default = null;
@@ -9790,6 +9880,10 @@ in
       };
       pruneDays = lib.mkOption {
         type = t.nullOr (t.int);
+        default = null;
+      };
+      resetArchiveRetention = lib.mkOption {
+        type = t.nullOr (t.oneOf [ (t.str) (t.number) (t.enum [ false ]) ]);
         default = null;
       };
       rotateBytes = lib.mkOption {
@@ -11221,6 +11315,19 @@ in
           type = t.nullOr (t.bool);
           default = null;
         };
+        gemini = lib.mkOption {
+          type = t.nullOr (t.submodule { options = {
+          apiKey = lib.mkOption {
+            type = t.nullOr (t.str);
+            default = null;
+          };
+          model = lib.mkOption {
+            type = t.nullOr (t.str);
+            default = null;
+          };
+        }; });
+          default = null;
+        };
         grok = lib.mkOption {
           type = t.nullOr (t.submodule { options = {
           apiKey = lib.mkOption {
@@ -11229,6 +11336,23 @@ in
           };
           inlineCitations = lib.mkOption {
             type = t.nullOr (t.bool);
+            default = null;
+          };
+          model = lib.mkOption {
+            type = t.nullOr (t.str);
+            default = null;
+          };
+        }; });
+          default = null;
+        };
+        kimi = lib.mkOption {
+          type = t.nullOr (t.submodule { options = {
+          apiKey = lib.mkOption {
+            type = t.nullOr (t.str);
+            default = null;
+          };
+          baseUrl = lib.mkOption {
+            type = t.nullOr (t.str);
             default = null;
           };
           model = lib.mkOption {
@@ -11260,7 +11384,7 @@ in
           default = null;
         };
         provider = lib.mkOption {
-          type = t.nullOr (t.oneOf [ (t.enum [ "brave" ]) (t.enum [ "perplexity" ]) (t.enum [ "grok" ]) ]);
+          type = t.nullOr (t.oneOf [ (t.enum [ "brave" ]) (t.enum [ "perplexity" ]) (t.enum [ "grok" ]) (t.enum [ "gemini" ]) (t.enum [ "kimi" ]) ]);
           default = null;
         };
         timeoutSeconds = lib.mkOption {

--- a/nix/packages/openclaw-app.nix
+++ b/nix/packages/openclaw-app.nix
@@ -6,11 +6,11 @@
 
 stdenvNoCC.mkDerivation {
   pname = "openclaw-app";
-  version = "2026.2.24";
+  version = "2026.2.25";
 
   src = fetchzip {
-    url = "https://github.com/openclaw/openclaw/releases/download/v2026.2.24/OpenClaw-2026.2.24.zip";
-    hash = "sha256-Gzc+3b2ooxu3AFk7lTiXyoPA/djkYDozxna9w4409ds=";
+    url = "https://github.com/openclaw/openclaw/releases/download/v2026.2.25/OpenClaw-2026.2.25.zip";
+    hash = "sha256-mSUImRLgV9lUlzhcYaAPwmCue8nTa7b359vqx1WBgsw=";
     stripRoot = false;
   };
 

--- a/nix/packages/openclaw-app.nix
+++ b/nix/packages/openclaw-app.nix
@@ -6,11 +6,11 @@
 
 stdenvNoCC.mkDerivation {
   pname = "openclaw-app";
-  version = "2026.2.23";
+  version = "2026.2.24";
 
   src = fetchzip {
-    url = "https://github.com/openclaw/openclaw/releases/download/v2026.2.23/OpenClaw-2026.2.23.zip";
-    hash = "sha256-J1L67xiPkPB+56tBM8r6Q/bQyEi4qtXdePDcDM67h5s=";
+    url = "https://github.com/openclaw/openclaw/releases/download/v2026.2.24/OpenClaw-2026.2.24.zip";
+    hash = "sha256-Gzc+3b2ooxu3AFk7lTiXyoPA/djkYDozxna9w4409ds=";
     stripRoot = false;
   };
 

--- a/nix/packages/openclaw-app.nix
+++ b/nix/packages/openclaw-app.nix
@@ -6,11 +6,11 @@
 
 stdenvNoCC.mkDerivation {
   pname = "openclaw-app";
-  version = "2026.2.19";
+  version = "2026.2.23";
 
   src = fetchzip {
-    url = "https://github.com/openclaw/openclaw/releases/download/v2026.2.19/OpenClaw-2026.2.19.zip";
-    hash = "sha256-qxMYho+mHj9IUBAwyYeOieBzVz9HPgBSj8It8ideGOM=";
+    url = "https://github.com/openclaw/openclaw/releases/download/v2026.2.23/OpenClaw-2026.2.23.zip";
+    hash = "sha256-J1L67xiPkPB+56tBM8r6Q/bQyEi4qtXdePDcDM67h5s=";
     stripRoot = false;
   };
 

--- a/nix/scripts/gateway-build.sh
+++ b/nix/scripts/gateway-build.sh
@@ -72,6 +72,20 @@ fi
 
 log_step "patchShebangs node_modules/.bin" bash -e -c ". \"$STDENV_SETUP\"; patchShebangs node_modules/.bin"
 
+# rolldown was removed from upstream direct dependencies (v2026.2.21+) but
+# remains in the pnpm store as a transitive dep (via rolldown-plugin-dts).
+# Upstream's bundle-a2ui.sh falls back to `pnpm dlx` which needs network.
+# Put rolldown on PATH so the script finds it directly.
+if ! command -v rolldown >/dev/null 2>&1; then
+  _rolldown_pkg="$(find node_modules/.pnpm -maxdepth 4 -path '*/rolldown@*/node_modules/rolldown' -print -quit 2>/dev/null || true)"
+  if [ -n "$_rolldown_pkg" ] && [ -f "$_rolldown_pkg/bin/cli.mjs" ]; then
+    _rolldown_shim="$(mktemp -d)"
+    printf '#!/bin/sh\nexec node "%s/bin/cli.mjs" "$@"\n' "$_rolldown_pkg" > "$_rolldown_shim/rolldown"
+    chmod +x "$_rolldown_shim/rolldown"
+    export PATH="$_rolldown_shim:$PATH"
+  fi
+fi
+
 # Break down `pnpm build` (upstream package.json) so we can profile it.
 log_step "build: canvas:a2ui:bundle" pnpm canvas:a2ui:bundle
 log_step "build: tsdown" pnpm exec tsdown

--- a/nix/scripts/gateway-tests-build.sh
+++ b/nix/scripts/gateway-tests-build.sh
@@ -22,6 +22,14 @@ if [ -z "${GATEWAY_PREBUILD_SH:-}" ]; then
   exit 1
 fi
 . "$GATEWAY_PREBUILD_SH"
+if [ -z "${STDENV_SETUP:-}" ]; then
+  echo "STDENV_SETUP is not set" >&2
+  exit 1
+fi
+if [ ! -f "$STDENV_SETUP" ]; then
+  echo "STDENV_SETUP not found: $STDENV_SETUP" >&2
+  exit 1
+fi
 
 store_path_file="${PNPM_STORE_PATH_FILE:-.pnpm-store-path}"
 if [ ! -f "$store_path_file" ]; then
@@ -37,13 +45,42 @@ export HOME="$(mktemp -d)"
 
 log_step "pnpm install (tests/config)" pnpm install --offline --frozen-lockfile --ignore-scripts --store-dir "$store_path"
 
-if [ -z "${STDENV_SETUP:-}" ]; then
-  echo "STDENV_SETUP is not set" >&2
-  exit 1
-fi
-if [ ! -f "$STDENV_SETUP" ]; then
-  echo "STDENV_SETUP not found: $STDENV_SETUP" >&2
-  exit 1
+log_step "chmod node_modules writable" chmod -R u+w node_modules
+
+# Rebuild native deps so rolldown (and other native modules) work.
+rebuild_list="$(jq -r '.pnpm.onlyBuiltDependencies // [] | .[]' package.json 2>/dev/null || true)"
+if [ -n "$rebuild_list" ]; then
+  log_step "pnpm rebuild (onlyBuiltDependencies)" env \
+    NODE_LLAMA_CPP_SKIP_DOWNLOAD=1 \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    PUPPETEER_SKIP_DOWNLOAD=1 \
+    ELECTRON_SKIP_BINARY_DOWNLOAD=1 \
+    pnpm rebuild $rebuild_list
+else
+  log_step "pnpm rebuild (all)" env \
+    NODE_LLAMA_CPP_SKIP_DOWNLOAD=1 \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    PUPPETEER_SKIP_DOWNLOAD=1 \
+    ELECTRON_SKIP_BINARY_DOWNLOAD=1 \
+    pnpm rebuild
 fi
 
 log_step "patchShebangs node_modules/.bin" bash -e -c ". \"$STDENV_SETUP\"; patchShebangs node_modules/.bin"
+
+# rolldown was removed from upstream direct dependencies (v2026.2.21+) but
+# remains in the pnpm store as a transitive dep (via rolldown-plugin-dts).
+# Upstream's bundle-a2ui.sh falls back to `pnpm dlx` which needs network.
+# Put rolldown on PATH so the script finds it directly.
+if ! command -v rolldown >/dev/null 2>&1; then
+  _rolldown_pkg="$(find node_modules/.pnpm -maxdepth 4 -path '*/rolldown@*/node_modules/rolldown' -print -quit 2>/dev/null || true)"
+  if [ -n "$_rolldown_pkg" ] && [ -f "$_rolldown_pkg/bin/cli.mjs" ]; then
+    _rolldown_shim="$(mktemp -d)"
+    printf '#!/bin/sh\nexec node "%s/bin/cli.mjs" "$@"\n' "$_rolldown_pkg" > "$_rolldown_shim/rolldown"
+    chmod +x "$_rolldown_shim/rolldown"
+    export PATH="$_rolldown_shim:$PATH"
+  fi
+fi
+
+# Build A2UI bundle so gateway tests that exercise canvas auth paths
+# can serve real assets instead of returning 503.
+log_step "build: canvas:a2ui:bundle" pnpm canvas:a2ui:bundle

--- a/nix/sources/openclaw-source.nix
+++ b/nix/sources/openclaw-source.nix
@@ -2,7 +2,7 @@
 {
   owner = "openclaw";
   repo = "openclaw";
-  rev = "0fe8f07e0ed9381ed6acb51de7623d991274a18b";
-  hash = "sha256-Q1PrWZdv46MkW6eRqi1oOnUh0DpFjRLjYaRlbwf1LW4=";
-  pnpmDepsHash = "sha256-BbgSf4Fz8S9u07WNGobqVCanMZLoGu3kGUvU1dYk4bE=";
+  rev = "a54dc7fe80fc02e2a02e6901668a468fcb0cf8b4";
+  hash = "sha256-xBBEpBRwZlghx2DPCGIpNgTPEMrrBFGkjPVEBrcBGKo=";
+  pnpmDepsHash = "sha256-x4uB91wUStN6ljiV1Jqx0qWK3RwAwd+5msbrlSb/sSE=";
 }

--- a/nix/sources/openclaw-source.nix
+++ b/nix/sources/openclaw-source.nix
@@ -2,7 +2,7 @@
 {
   owner = "openclaw";
   repo = "openclaw";
-  rev = "a54dc7fe80fc02e2a02e6901668a468fcb0cf8b4";
-  hash = "sha256-xBBEpBRwZlghx2DPCGIpNgTPEMrrBFGkjPVEBrcBGKo=";
+  rev = "b817600533129771ace2801d7c05901c7f850fb8";
+  hash = "sha256-TCBuoAHquGImmyiCRfJZ1flGAddQ3Uds0I3njTaif0w=";
   pnpmDepsHash = "sha256-x4uB91wUStN6ljiV1Jqx0qWK3RwAwd+5msbrlSb/sSE=";
 }

--- a/nix/sources/openclaw-source.nix
+++ b/nix/sources/openclaw-source.nix
@@ -2,7 +2,7 @@
 {
   owner = "openclaw";
   repo = "openclaw";
-  rev = "b817600533129771ace2801d7c05901c7f850fb8";
-  hash = "sha256-TCBuoAHquGImmyiCRfJZ1flGAddQ3Uds0I3njTaif0w=";
-  pnpmDepsHash = "sha256-x4uB91wUStN6ljiV1Jqx0qWK3RwAwd+5msbrlSb/sSE=";
+  rev = "819cec3c406a45d231057e37ace2f68cb6769255";
+  hash = "sha256-VpGi4euHx5bQoZ7DqWeYT92fPw7sHbdreas+SBzlURw=";
+  pnpmDepsHash = "sha256-G+wDPYzn3Ce71XmqDtbBYTsOX9f/JjEaDnknxXLIDPw=";
 }

--- a/nix/sources/openclaw-source.nix
+++ b/nix/sources/openclaw-source.nix
@@ -2,7 +2,7 @@
 {
   owner = "openclaw";
   repo = "openclaw";
-  rev = "819cec3c406a45d231057e37ace2f68cb6769255";
-  hash = "sha256-VpGi4euHx5bQoZ7DqWeYT92fPw7sHbdreas+SBzlURw=";
-  pnpmDepsHash = "sha256-G+wDPYzn3Ce71XmqDtbBYTsOX9f/JjEaDnknxXLIDPw=";
+  rev = "4b5d4a4c660d05e4bd73f0e11123e68fd9664432";
+  hash = "sha256-2PYEeERGmdrmP8bwJlj3fyyqtx9hNDnjT4nvVN0awUc=";
+  pnpmDepsHash = "sha256-BjJze+4IGmQLttN1z8/kEPii8qvKjLFN56AArvipluo=";
 }


### PR DESCRIPTION
Hi — first-time contributor to the repo here. README discourages opening PRs by us non-established contributors; if this doesn't suit & you'd rather break it down into per-issue PRs or similar, I get it! But I'm scratching my own itch to address #62 and #64 so I can myself be on OpenClaw latest, and figure it's worth sharing the fruits of ~~my~~ Claude's labor.

## What this PR does

The goal is to get `nix-openclaw` onto the latest upstream OpenClaw release — currently **v2026.2.25**. Nominally that's something the upstream OpenClaw's CI pipeline should do--but we've got some dependency shifts that break here, so that pipeline would be red. The build and test fixes in this PR are the "real work" and are present in service of that. They could be broken out into separate per-issue PRs if preferred, but they form a nice atomic unit since each fix was needed to unblock the bump, which effectively proves their effectiveness (and makes this changeset actually _useful_ instead of just plumbing).

More details in "Fix" section; this is more than just repinning because some underlying deps needed cleanup (for rolldown) or exclusion (`bird`'s OpenClaw-friendly repo was deleted entirely).

## Problem

Starting with upstream v2026.2.21, openclaw removed `rolldown` from direct `devDependencies`. Their `bundle-a2ui.sh` now falls back to `pnpm dlx rolldown`, which requires network access — blocked in the Nix sandbox. Separately, the upstream refactor in `2dcb2449` renamed `server.canvas-auth.e2e.test.ts` to `.test.ts`, bringing it into the gateway vitest suite for the first time. That test expects A2UI assets on disk, but the Nix test build never produced them. And on top of that, the `steipete/bird` GitHub repo has been deleted, so the darwin tools bundle can't fetch its release binary.

## Fix

Six commits:

1. **Rolldown PATH shim + pin bump to v2026.2.22** — `rolldown` remains in the pnpm store as a transitive dep (via `rolldown-plugin-dts`). Before the `canvas:a2ui:bundle` step, we locate it in `node_modules/.pnpm/` and create a PATH shim so the upstream script's `command -v rolldown` check passes without network access.

2. **Regenerate config options** — golden file updated for the new upstream schema.

3. **Add A2UI bundle step to test build** — adds `pnpm rebuild` (native deps), the same rolldown PATH shim, and `pnpm canvas:a2ui:bundle` to `gateway-tests-build.sh` so the canvas-auth test can serve real assets.

4. **Bump pins to v2026.2.25** — source pin, macOS app, and regenerated config options for the latest upstream release.

5. **Exclude bird from tools bundle** — the `steipete/bird` GitHub repo was deleted, so release asset downloads 404. This was breaking the darwin CI aggregator. Filed upstream: https://github.com/openclaw/nix-steipete-tools/issues/6

Closes #62
Closes #64

## Test plan

- [x] `nix build .#checks.x86_64-linux.ci` — full Linux CI (gateway build, tests, config validity, config options, package contents, default instance, HM activation VM test)
- [x] `nix build .#checks.aarch64-darwin.ci` — full darwin CI (gateway, app, config validity, tools bundle)
- [x] `home-manager switch` on aarch64-darwin — reports `openclaw 2026.2.25`
- [x] Verified bird 404 is pre-existing on `main` (not introduced by this PR)
- [x] Verified `bird` is fully absent from derivation inputs after exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)