### PR TITLE
fix: add A2UI bundle step to gateway test build

### DIFF
--- a/nix/scripts/gateway-tests-build.sh
+++ b/nix/scripts/gateway-tests-build.sh
@@ -22,6 +22,14 @@ if [ -z "${GATEWAY_PREBUILD_SH:-}" ]; then
   exit 1
 fi
 . "$GATEWAY_PREBUILD_SH"
+if [ -z "${STDENV_SETUP:-}" ]; then
+  echo "STDENV_SETUP is not set" >&2
+  exit 1
+fi
+if [ ! -f "$STDENV_SETUP" ]; then
+  echo "STDENV_SETUP not found: $STDENV_SETUP" >&2
+  exit 1
+fi
 
 store_path_file="${PNPM_STORE_PATH_FILE:-.pnpm-store-path}"
 if [ ! -f "$store_path_file" ]; then
@@ -37,13 +45,42 @@ export HOME="$(mktemp -d)"
 
 log_step "pnpm install (tests/config)" pnpm install --offline --frozen-lockfile --ignore-scripts --store-dir "$store_path"
 
-if [ -z "${STDENV_SETUP:-}" ]; then
-  echo "STDENV_SETUP is not set" >&2
-  exit 1
-fi
-if [ ! -f "$STDENV_SETUP" ]; then
-  echo "STDENV_SETUP not found: $STDENV_SETUP" >&2
-  exit 1
+log_step "chmod node_modules writable" chmod -R u+w node_modules
+
+# Rebuild native deps so rolldown (and other native modules) work.
+rebuild_list="$(jq -r '.pnpm.onlyBuiltDependencies // [] | .[]' package.json 2>/dev/null || true)"
+if [ -n "$rebuild_list" ]; then
+  log_step "pnpm rebuild (onlyBuiltDependencies)" env \
+    NODE_LLAMA_CPP_SKIP_DOWNLOAD=1 \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    PUPPETEER_SKIP_DOWNLOAD=1 \
+    ELECTRON_SKIP_BINARY_DOWNLOAD=1 \
+    pnpm rebuild $rebuild_list
+else
+  log_step "pnpm rebuild (all)" env \
+    NODE_LLAMA_CPP_SKIP_DOWNLOAD=1 \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    PUPPETEER_SKIP_DOWNLOAD=1 \
+    ELECTRON_SKIP_BINARY_DOWNLOAD=1 \
+    pnpm rebuild
 fi
 
 log_step "patchShebangs node_modules/.bin" bash -e -c ". \"$STDENV_SETUP\"; patchShebangs node_modules/.bin"
+
+# rolldown was removed from upstream direct dependencies (v2026.2.21+) but
+# remains in the pnpm store as a transitive dep (via rolldown-plugin-dts).
+# Upstream's bundle-a2ui.sh falls back to `pnpm dlx` which needs network.
+# Put rolldown on PATH so the script finds it directly.
+if ! command -v rolldown >/dev/null 2>&1; then
+  _rolldown_pkg="$(find node_modules/.pnpm -maxdepth 4 -path '*/rolldown@*/node_modules/rolldown' -print -quit 2>/dev/null || true)"
+  if [ -n "$_rolldown_pkg" ] && [ -f "$_rolldown_pkg/bin/cli.mjs" ]; then
+    _rolldown_shim="$(mktemp -d)"
+    printf '#!/bin/sh\nexec node "%s/bin/cli.mjs" "$@"\n' "$_rolldown_pkg" > "$_rolldown_shim/rolldown"
+    chmod +x "$_rolldown_shim/rolldown"
+    export PATH="$_rolldown_shim:$PATH"
+  fi
+fi
+
+# Build A2UI bundle so gateway tests that exercise canvas auth paths
+# can serve real assets instead of returning 503.
+log_step "build: canvas:a2ui:bundle" pnpm canvas:a2ui:bundle


### PR DESCRIPTION
Hi there — first-time contributor here. We ran into this while working on #62 (the rolldown/sandbox build fix in #63). Happy to adjust anything that doesn't fit your preferences.

## Problem

Upstream commit `2dcb2449` ("refactor(test): dedupe gateway and web scaffolding") renamed `server.canvas-auth.e2e.test.ts` to `server.canvas-auth.test.ts`. The vitest base config excludes `**/*.e2e.test.ts`, so this rename brought the canvas-auth test into the gateway vitest suite for the first time.

The test expects a scoped A2UI fetch to return HTTP 200, but `gateway-tests-build.sh` only ran `pnpm install` — it never produced `a2ui.bundle.js`. Without the bundle, the A2UI handler returns 503 ("A2UI assets not found"), causing the test to fail.

## Fix

Add the minimal build steps needed to produce the A2UI bundle in the test environment:

1. `chmod -R u+w node_modules` (required for `pnpm rebuild`)
2. `pnpm rebuild` for native deps (same download-blocker pattern as the production build)
3. Rolldown PATH shim (rolldown was removed from direct devDependencies upstream but remains as a transitive dep via `rolldown-plugin-dts`)
4. `pnpm canvas:a2ui:bundle`

The STDENV_SETUP check is also moved earlier in the script to match the production build's ordering.

## Verification

- Confirmed the canvas-auth test passes at v2026.2.22 (upcoming pin bump in #63) with these changes
- Confirmed the change is harmless at the current pin (v2026.2.20) — the bundle is produced but the canvas-auth test is still excluded as `.e2e.test.ts` at that version

Closes #64

## Test plan

- [x] `nix build .#checks.x86_64-linux.gateway-tests` passes at v2026.2.22 — 54 test files, 553 tests, all green
- [x] `nix build .#checks.x86_64-linux.gateway-tests` at v2026.2.20 — no regression from this change (pre-existing `net.test.ts` failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)