### PR TITLE
Resolve bundled plugins from flake input instead of hardcoded rev

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
               };
               config-validity = pkgs.callPackage ./nix/checks/openclaw-config-validity.nix {
                 openclawGateway = packageSetStable.openclaw-gateway;
+                steipeteToolsInput = nix-steipete-tools;
               };
             }
             // (
@@ -84,10 +85,14 @@
                   };
                   config-options = pkgs.callPackage ./nix/checks/openclaw-config-options.nix {
                     sourceInfo = sourceInfoStable;
+                    steipeteToolsInput = nix-steipete-tools;
                   };
-                  default-instance = pkgs.callPackage ./nix/checks/openclaw-default-instance.nix { };
+                  default-instance = pkgs.callPackage ./nix/checks/openclaw-default-instance.nix {
+                    steipeteToolsInput = nix-steipete-tools;
+                  };
                   hm-activation = import ./nix/checks/openclaw-hm-activation.nix {
                     inherit pkgs home-manager;
+                    steipeteToolsInput = nix-steipete-tools;
                   };
                 }
               else
@@ -121,7 +126,11 @@
     // {
       overlays.default = overlay;
       nixosModules.openclaw-gateway = import ./nix/modules/nixos/openclaw-gateway.nix;
-      homeManagerModules.openclaw = import ./nix/modules/home-manager/openclaw.nix;
-      darwinModules.openclaw = import ./nix/modules/darwin/openclaw.nix;
+      homeManagerModules.openclaw = {
+        _module.args.steipeteToolsInput = nix-steipete-tools;
+        imports = [ ./nix/modules/home-manager/openclaw ];
+      };
+      darwinModules.openclaw =
+        import ./nix/modules/darwin/openclaw.nix { inherit nix-steipete-tools; };
     };
 }

--- a/nix/checks/openclaw-config-options.nix
+++ b/nix/checks/openclaw-config-options.nix
@@ -3,6 +3,7 @@
   pkgs,
   stdenv,
   fetchFromGitHub,
+  steipeteToolsInput,
   fetchurl,
   nodejs_22,
   pnpm_10,
@@ -76,7 +77,8 @@ let
   pluginEval = lib.evalModules {
     modules = [
       stubModule
-      ../modules/home-manager/openclaw.nix
+      { _module.args.steipeteToolsInput = steipeteToolsInput; }
+      ../modules/home-manager/openclaw
       (
         { lib, options, ... }:
         {

--- a/nix/checks/openclaw-config-validity.nix
+++ b/nix/checks/openclaw-config-validity.nix
@@ -4,6 +4,7 @@
   stdenv,
   nodejs_22,
   openclawGateway,
+  steipeteToolsInput,
 }:
 
 let
@@ -61,7 +62,8 @@ let
   moduleEval = lib.evalModules {
     modules = [
       stubModule
-      ../modules/home-manager/openclaw.nix
+      { _module.args.steipeteToolsInput = steipeteToolsInput; }
+      ../modules/home-manager/openclaw
       (
         { lib, ... }:
         {

--- a/nix/checks/openclaw-default-instance.nix
+++ b/nix/checks/openclaw-default-instance.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   stdenv,
+  steipeteToolsInput,
 }:
 
 let
@@ -59,7 +60,8 @@ let
   eval = lib.evalModules {
     modules = [
       stubModule
-      ../modules/home-manager/openclaw.nix
+      { _module.args.steipeteToolsInput = steipeteToolsInput; }
+      ../modules/home-manager/openclaw
       (
         { lib, ... }:
         {

--- a/nix/checks/openclaw-hm-activation.nix
+++ b/nix/checks/openclaw-hm-activation.nix
@@ -1,7 +1,10 @@
-{ pkgs, home-manager }:
+{ pkgs, home-manager, steipeteToolsInput }:
 
 let
-  openclawModule = ../modules/home-manager/openclaw.nix;
+  openclawModule = {
+    _module.args.steipeteToolsInput = steipeteToolsInput;
+    imports = [ ../modules/home-manager/openclaw ];
+  };
   testScript = builtins.readFile ../tests/hm-activation.py;
 
 in

--- a/nix/modules/darwin/openclaw.nix
+++ b/nix/modules/darwin/openclaw.nix
@@ -1,7 +1,13 @@
+{ nix-steipete-tools }:
 { config, lib, ... }:
 
 {
   config = lib.mkIf (config ? home-manager) {
-    home-manager.sharedModules = [ ../home-manager/openclaw.nix ];
+    home-manager.sharedModules = [
+      {
+        _module.args.steipeteToolsInput = nix-steipete-tools;
+        imports = [ ../home-manager/openclaw ];
+      }
+    ];
   };
 }

--- a/nix/modules/home-manager/openclaw/config.nix
+++ b/nix/modules/home-manager/openclaw/config.nix
@@ -2,11 +2,12 @@
   config,
   lib,
   pkgs,
+  steipeteToolsInput,
   ...
 }:
 
 let
-  openclawLib = import ./lib.nix { inherit config lib pkgs; };
+  openclawLib = import ./lib.nix { inherit config lib pkgs steipeteToolsInput; };
   cfg = openclawLib.cfg;
   homeDir = openclawLib.homeDir;
   appPackage = openclawLib.appPackage;
@@ -51,6 +52,7 @@ let
       pkgs
       openclawLib
       enabledInstances
+      steipeteToolsInput
       ;
   };
 

--- a/nix/modules/home-manager/openclaw/lib.nix
+++ b/nix/modules/home-manager/openclaw/lib.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  steipeteToolsInput,
 }:
 
 let
@@ -26,11 +27,10 @@ let
 
   bundledPluginSources =
     let
-      stepieteRev = "c110209720cbc6c87fccb6c1e1c2b79b1d719245";
-      stepieteNarHash = "sha256-1Vo7rcLGdKaqj39J3HhBKh8IbljSjgCUhinCFJbDPl8=";
-      stepiete =
-        tool:
-        "github:openclaw/nix-steipete-tools?dir=tools/${tool}&rev=${stepieteRev}&narHash=${stepieteNarHash}";
+      # Use a "bundled:" URI scheme that plugins.nix resolves by importing the
+      # sub-flake directly from the nix-steipete-tools source tree, avoiding
+      # builtins.getFlake and its lockfile warnings.
+      stepiete = tool: "bundled:steipete/${tool}";
     in
     lib.mapAttrs (_name: plugin: plugin.source or (stepiete plugin.tool)) pluginCatalog;
 

--- a/nix/modules/home-manager/openclaw/options.nix
+++ b/nix/modules/home-manager/openclaw/options.nix
@@ -2,11 +2,12 @@
   config,
   lib,
   pkgs,
+  steipeteToolsInput,
   ...
 }:
 
 let
-  openclawLib = import ./lib.nix { inherit config lib pkgs; };
+  openclawLib = import ./lib.nix { inherit config lib pkgs steipeteToolsInput; };
   instanceModule = import ./options-instance.nix { inherit lib openclawLib; };
   pluginCatalog = import ./plugin-catalog.nix;
   mkSkillOption = lib.types.submodule {

--- a/nix/modules/home-manager/openclaw/plugins.nix
+++ b/nix/modules/home-manager/openclaw/plugins.nix
@@ -3,16 +3,37 @@
   pkgs,
   openclawLib,
   enabledInstances,
+  steipeteToolsInput,
 }:
 
 let
   resolvePath = openclawLib.resolvePath;
   toRelative = openclawLib.toRelative;
 
+  # Resolve a "bundled:steipete/<tool>" source by importing the sub-flake
+  # directly from the steipeteToolsInput source tree instead of calling
+  # builtins.getFlake with a URL (which requires a committed flake.lock in
+  # every sub-flake directory to avoid warnings).
+  resolveBundledFlake =
+    source:
+    let
+      tool = lib.removePrefix "bundled:steipete/" source;
+      subFlakeNix = import "${steipeteToolsInput}/tools/${tool}/flake.nix";
+    in
+    subFlakeNix.outputs {
+      self = { };
+      nixpkgs = { inherit lib; };
+      root = steipeteToolsInput;
+    };
+
   resolvePlugin =
     plugin:
     let
-      flake = builtins.getFlake plugin.source;
+      flake =
+        if lib.hasPrefix "bundled:" plugin.source then
+          resolveBundledFlake plugin.source
+        else
+          builtins.getFlake plugin.source;
       system = pkgs.stdenv.hostPlatform.system;
       openclawPluginRaw =
         if flake ? openclawPlugin then


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `stepieteRev`/`stepieteNarHash` in `lib.nix` with direct sub-flake evaluation from the `nix-steipete-tools` flake input
- Eliminates `not writing modified lock file` warnings caused by `builtins.getFlake` on sub-flakes without committed `flake.lock` files
- Allows downstream consumers to override `nix-steipete-tools` via the standard flake `follows` mechanism

## Approach
- Introduces a `bundled:` URI scheme: `lib.nix` produces `bundled:steipete/<tool>` source strings
- `plugins.nix` handles these by importing and evaluating the sub-flake directly from the `nix-steipete-tools` source tree, bypassing `builtins.getFlake` entirely
- Custom (non-bundled) plugins continue using `builtins.getFlake` as before
- The `nix-steipete-tools` input is threaded through the module system via the standard closure pattern

## Dependencies
- Temporarily points `nix-steipete-tools` input to `dansanduleac/nix-steipete-tools` (openclaw/nix-steipete-tools#8) which adds `tools/summarize/flake.lock` — revert to `openclaw/nix-steipete-tools` once that's merged

## Test plan
- [x] `nix flake check` passes with no `not writing modified lock file` warnings
- [ ] Verify bundled plugin resolution works end-to-end on Linux (summarize, goplaces, etc.)
- [ ] Verify custom plugins still resolve via `builtins.getFlake`

🤖 Generated with [Claude Code](https://claude.com/claude-code)