### PR TITLE
Gateway: link long for @whiskeysockets/baileys

### DIFF
--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -115,6 +115,23 @@ if [ -n "$hasown_src" ]; then
   fi
 fi
 
+# Work around missing 'long' dependency for @whiskeysockets/baileys in pnpm layout.
+# messages-recv.js has a top-level `import Long from 'long'` but baileys does not
+# declare 'long' in its package.json, so pnpm strict mode never creates the symlink
+# in baileys' virtual node_modules directory.
+long_src="$(find "$out/lib/openclaw/node_modules/.pnpm" -path "*/long@4*/node_modules/long" -print | head -n 1)"
+if [ -n "$long_src" ]; then
+  baileys_pkgs="$(find "$out/lib/openclaw/node_modules/.pnpm" -path "*/@whiskeysockets+baileys*/node_modules" -maxdepth 3 -type d -print)"
+  if [ -n "$baileys_pkgs" ]; then
+    for pkg in $baileys_pkgs; do
+      if [ ! -e "$pkg/long" ]; then
+        mkdir -p "$pkg"
+        ln -s "$long_src" "$pkg/long"
+      fi
+    done
+  fi
+fi
+
 log_step "validate node_modules symlinks" check_no_broken_symlinks "$out/lib/openclaw/node_modules"
 
 bash -e -c '. "$STDENV_SETUP"; makeWrapper "$NODE_BIN" "$out/bin/openclaw" --add-flags "$out/lib/openclaw/dist/index.js" --set-default OPENCLAW_NIX_MODE "1"'


### PR DESCRIPTION
## Problem

`@whiskeysockets/baileys@7.0.0-rc.9` has a static top-level ESM import in `messages-recv.js`:

\`\`\`js
import Long from 'long'
\`\`\`

But `long` is not declared in baileys' `package.json` dependencies. pnpm strict mode therefore never creates the symlink in baileys' virtual node_modules directory. This causes a hard crash at startup when a Telegram channel is configured:

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'long' imported from
.../node_modules/.pnpm/@whiskeysockets+baileys@7.0.0-rc.9.../node_modules/@whiskeysockets/baileys/lib/Socket/messages-recv.js
\`\`\`

The crash is silent to the vitest suite (gateway-tests only run unit tests, never open a real Telegram socket), so CI passes while real deployments fail.

## Fix

Follows the exact same pattern already used in this script for `combined-stream`, `hasown`, and `strip-ansi`: find the package in the pnpm store and symlink it into baileys' virtual node_modules.

## Related

Analogous to #45 (missing `hasown`).