### PR TITLE
fix: copy plugin manifests into dist/extensions

### DIFF
--- a/nix/scripts/gateway-install.sh
+++ b/nix/scripts/gateway-install.sh
@@ -45,6 +45,21 @@ if [ -d extensions ]; then
   log_step "copy extensions" cp -r extensions "$out/lib/openclaw/"
 fi
 
+# Copy plugin manifests into dist/extensions/ where the gateway expects them.
+# The TypeScript build emits compiled .js into dist/extensions/*/ but does not
+# copy the openclaw.plugin.json manifests, so the gateway fails to discover
+# plugins at runtime.
+if [ -d "$out/lib/openclaw/extensions" ] && [ -d "$out/lib/openclaw/dist/extensions" ]; then
+  for manifest in "$out/lib/openclaw/extensions"/*/openclaw.plugin.json; do
+    [ -f "$manifest" ] || continue
+    name="$(basename "$(dirname "$manifest")")"
+    dist_ext="$out/lib/openclaw/dist/extensions/$name"
+    if [ -d "$dist_ext" ] && [ ! -f "$dist_ext/openclaw.plugin.json" ]; then
+      cp "$manifest" "$dist_ext/openclaw.plugin.json"
+    fi
+  done
+fi
+
 if [ -d docs/reference/templates ]; then
   mkdir -p "$out/lib/openclaw/docs/reference"
   log_step "copy reference templates" cp -r docs/reference/templates "$out/lib/openclaw/docs/reference/"


### PR DESCRIPTION
## Summary

- The gateway discovers plugins by looking for `openclaw.plugin.json` manifests at `dist/extensions/*/openclaw.plugin.json`
- The TypeScript build emits compiled `.js` files into `dist/extensions/*/` but does **not** copy the `openclaw.plugin.json` manifests from the source `extensions/` tree
- After the existing extensions copy step in `gateway-install.sh`, iterate over `extensions/*/openclaw.plugin.json` and copy each manifest into its corresponding `dist/extensions/*/` directory so the gateway can discover plugins at runtime

Relates to #6, #14.

## Test plan

- [ ] Build the Nix package and verify `dist/extensions/*/openclaw.plugin.json` files exist in the output
- [ ] Start the gateway and confirm plugins are discovered and loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)