### PR TITLE
fix: enable nixMode in appDefaults configuration

### DIFF
--- a/nix/modules/home-manager/openclaw/config.nix
+++ b/nix/modules/home-manager/openclaw/config.nix
@@ -28,6 +28,7 @@ let
     appDefaults = {
       enable = true;
       attachExistingOnly = true;
+      nixMode = true;
     };
     app = {
       install = {


### PR DESCRIPTION
Add missing default causing this error:
```shell
       error: attribute 'nixMode' missing
       at /nix/store/lzp5yvryxwx2bgfmsiabnm3qgc2fcznx-source/nix/modules/home-manager/openclaw/config.nix:155:19:
          154|         gatewayPort = inst.gatewayPort;
          155|         nixMode = inst.appDefaults.nixMode;
             |                   ^
          156|       };
```