### PR TITLE
fix: accept stable config validator entrypoint

### DIFF
--- a/nix/scripts/check-config-validity.mjs
+++ b/nix/scripts/check-config-validity.mjs
@@ -17,6 +17,7 @@ if (!srcRoot) {
 }
 
 const legacyValidationPath = path.join(srcRoot, "dist", "config", "validation.js");
+const stableConfigPath = path.join(srcRoot, "dist", "config", "config.js");
 const distDir = path.join(srcRoot, "dist");
 
 let validateConfigObject = null;
@@ -25,6 +26,11 @@ if (fs.existsSync(legacyValidationPath)) {
   const moduleUrl = pathToFileURL(legacyValidationPath).href;
   const legacyModule = await import(moduleUrl);
   validateConfigObject = legacyModule.validateConfigObject;
+} else if (fs.existsSync(stableConfigPath)) {
+  const moduleUrl = pathToFileURL(stableConfigPath).href;
+  const configModule = await import(moduleUrl);
+  validateConfigObject =
+    configModule.validateConfigObject ?? configModule.validateConfigObjectWithPlugins;
 } else if (fs.existsSync(distDir)) {
   const candidates = fs.readdirSync(distDir)
     .filter((name) => name.startsWith("config-") && name.endsWith(".js"));


### PR DESCRIPTION
## What

Allow config-validity to load OpenClaw’s stable `dist/config/config.js` validator entrypoint.

## Why

Yolo pin sync selects and materializes `v2026.4.26`, but promotion fails because the check still expects `dist/config/validation.js`.

## Test

- `node --check nix/scripts/check-config-validity.mjs`
- `nix build .#checks.aarch64-darwin.config-validity --accept-flake-config`