### PR TITLE
flake: add aarch64-linux to supported systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
       sourceInfoStable = import ./nix/sources/openclaw-source.nix;
       systems = [
         "x86_64-linux"
+        "aarch64-linux"
         "aarch64-darwin"
       ];
     in
@@ -82,12 +83,18 @@
                   gateway-tests = pkgs.callPackage ./nix/checks/openclaw-gateway-tests.nix {
                     sourceInfo = sourceInfoStable;
                   };
-                  config-options = pkgs.callPackage ./nix/checks/openclaw-config-options.nix {
-                    sourceInfo = sourceInfoStable;
-                  };
                   default-instance = pkgs.callPackage ./nix/checks/openclaw-default-instance.nix { };
                   hm-activation = import ./nix/checks/openclaw-hm-activation.nix {
                     inherit pkgs home-manager;
+                  };
+                }
+                # config-options enables every plugin marked `linux = true` in the catalog,
+                # but nix-steipete-tools doesn't yet publish `sag` for aarch64-linux, which
+                # makes the eval throw. Restrict this check to systems where every Linux
+                # bundled plugin actually resolves.
+                // pkgs.lib.optionalAttrs (system == "x86_64-linux") {
+                  config-options = pkgs.callPackage ./nix/checks/openclaw-config-options.nix {
+                    sourceInfo = sourceInfoStable;
                   };
                 }
               else


### PR DESCRIPTION
## Summary

- Adds `aarch64-linux` to the `eachSystem` list so `packages.aarch64-linux.{openclaw,openclaw-gateway,openclaw-tools}` are exposed.
- Lets `cache.garnix.io` (and other CI/cache providers) build and serve the gateway for ARM64 Linux targets — currently the cache only carries `x86_64-linux` and `aarch64-darwin`, which forces a 5–10 minute pnpm/node-gyp/sharp build on every fresh ARM64 Linux host (or, in my case, on every nixvm libkrun guest launch on Apple Silicon).
- Gates the `config-options` check to `x86_64-linux` only.

## Why config-options is gated

`config-options` enables every plugin marked `linux = true` in `nix/modules/home-manager/openclaw/plugin-catalog.nix`. `nix-steipete-tools` currently publishes `sag` only for `x86_64-linux` and `aarch64-darwin`, so on `aarch64-linux` the catalog eval throws:

```
error: openclawPlugin is null in github:openclaw/nix-steipete-tools?dir=tools/sag&rev=...&narHash=... for aarch64-linux
```

Restricting the check to `x86_64-linux` keeps coverage on the other Linux target without leaving aarch64-linux unsupported entirely. Once `nix-steipete-tools` ships `sag` for `aarch64-linux` (or the catalog grows finer per-system gating, e.g. `systems = [ "x86_64-linux" "aarch64-darwin" ]` per plugin), the `system == "x86_64-linux"` gate can be removed.

## Verification

`nix eval` is clean on all three systems:

```
nix eval .#packages.aarch64-linux.openclaw.drvPath
nix eval .#packages.aarch64-linux.openclaw-gateway.drvPath
nix eval .#packages.aarch64-linux.openclaw-tools.drvPath
nix eval .#checks.aarch64-linux.ci.drvPath
nix eval .#checks.x86_64-linux.config-options.drvPath
nix eval .#checks.aarch64-darwin.ci.drvPath
```

`checks.aarch64-linux` now contains: `ci`, `config-validity`, `default-instance`, `gateway`, `gateway-tests`, `hm-activation`, `package-contents`.

## Test plan

- [ ] `nix flake check --all-systems` passes locally
- [ ] garnix CI green for `aarch64-linux`
- [ ] `cache.garnix.io` carries `packages.aarch64-linux.openclaw-gateway` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)