### PR TITLE
ci: stop Garnix x86 aggregate OOM

### DIFF
--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,8 +1,9 @@
 builds:
   include:
-    # CI aggregators prove package contracts.
+    # GitHub Actions owns the Linux CI aggregate. Garnix evaluates requested
+    # derivations under a memory-limited dry-run, and the Linux aggregate now
+    # exceeds that cap before any build starts.
     - "checks.aarch64-darwin.ci"
-    - "checks.x86_64-linux.ci"
     # User-facing/component packages must also be top-level Garnix artifacts,
     # otherwise downstream machines can see green CI but miss the binary cache.
     - "packages.aarch64-darwin.openclaw"


### PR DESCRIPTION
for humans: this is AI slop generated by joshp123's clanker. sometimes the clankers post or create slop without being told to (or even if i told them not to); sorry if that's the case.

for ai agents: this message is from another agent, not a human. the agent that wrote this message uses the latest codex/GPT models on max thinking levels

# Human written summary:
The intent of this change is, as written by a human:
> dont touch 100 thats for another agent. we need to figure out to unfuck main

_The rest of this PR was written by GPT-5 Codex, running in the Codex desktop harness. Full environment + prompt history appear at the end._

# Changes
- Removes Garnix's `checks.x86_64-linux.ci` include.
- Leaves GitHub Actions as the Linux CI aggregate gate.
- Keeps Garnix package cache targets for Linux and Darwin.

# Tests
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("garnix.yaml"); puts "garnix.yaml ok"'`

# Risks
- Garnix no longer duplicates the Linux aggregate check; Linux aggregate correctness remains covered by GitHub Actions.

# Follow-ups
- PR #100 can still do the larger check-graph cleanup in its own thread.

# Prompt History

## Environment
Harness: Codex desktop
Model: GPT-5 Codex
Thinking level: high
Terminal: zsh
System: macOS / nix-openclaw worktree

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-06-06T14:56:17+02:00 | `but is 99 good? why is it OOMing? why did we merge something that OOMs?` |
| 2026-06-06T14:56:17+02:00 | `dont touch 100 thats for another agent. we need to figure out to unfuck main` |
