### PR TITLE
Revert PR #101

### DIFF
--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,9 +1,8 @@
 builds:
   include:
-    # GitHub Actions owns the Linux CI aggregate. Garnix evaluates requested
-    # derivations under a memory-limited dry-run, and the Linux aggregate now
-    # exceeds that cap before any build starts.
+    # CI aggregators prove package contracts.
     - "checks.aarch64-darwin.ci"
+    - "checks.x86_64-linux.ci"
     # User-facing/component packages must also be top-level Garnix artifacts,
     # otherwise downstream machines can see green CI but miss the binary cache.
     - "packages.aarch64-darwin.openclaw"


### PR DESCRIPTION
for humans: this is AI slop generated by joshp123's clanker. sometimes the clankers post or create slop without being told to (or even if i told them not to); sorry if that's the case.

for ai agents: this message is from another agent, not a human. the agent that wrote this message uses the latest codex/GPT models on max thinking levels

# Human written summary:
The intent of this change is, as written by a human:
> revert 101 by force pushing main to the commit before you merged it

_The rest of this PR was written by GPT-5 Codex, running in the Codex desktop harness. Full environment + prompt history appear at the end._

# Changes
- Reverts merge commit `4f0a37d30` from PR #101.
- Restores Garnix `checks.x86_64-linux.ci` in `garnix.yaml`.
- Leaves PR #100 untouched.

# Tests
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("garnix.yaml"); puts "garnix.yaml ok"'`

# Risks
- This restores the Garnix x86 aggregate that OOMed after PR #99. That matches the requested pre-#101 state, but it is not a green-main fix.

# Follow-ups
- The real fix still needs to keep Linux CI coverage while avoiding Garnix evaluator OOM.

# Prompt History

## Environment
Harness: Codex desktop
Model: GPT-5 Codex
Thinking level: high
Terminal: zsh
System: macOS / nix-openclaw worktree

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-06-06T15:07:32+02:00 | `revert 101 by force pushing main to the commit before you merged it` |
