### PR TITLE
[codex] fix package content check for public surface candidates

### DIFF
--- a/nix/scripts/check-package-contents.sh
+++ b/nix/scripts/check-package-contents.sh
@@ -62,16 +62,51 @@ if (!loaderPath) {
 
 const loader = await import(pathToFileURL(loaderPath).href);
 const loadBundledPluginPublicArtifactModuleSync =
-  loader.loadBundledPluginPublicArtifactModuleSync ?? loader.t;
+  loader.loadBundledPluginPublicArtifactModuleSync;
+const loadBundledPluginPublicArtifactModuleFromCandidatesSync =
+  loader.loadBundledPluginPublicArtifactModuleFromCandidatesSync;
+const minifiedLoader = loader.t;
 
-if (typeof loadBundledPluginPublicArtifactModuleSync !== "function") {
+if (
+  typeof loadBundledPluginPublicArtifactModuleSync !== "function" &&
+  typeof loadBundledPluginPublicArtifactModuleFromCandidatesSync !== "function" &&
+  typeof minifiedLoader !== "function"
+) {
   throw new Error("Bundled plugin public surface loader export not found");
 }
 
-loadBundledPluginPublicArtifactModuleSync({
+const loadSingleParams = {
   dirName: "openai",
   artifactBasename: "provider-policy-api.js",
-});
+};
+const loadCandidateParams = {
+  dirName: "openai",
+  artifactCandidates: ["provider-policy-api.js"],
+};
+
+function loadPublicArtifact() {
+  if (typeof loadBundledPluginPublicArtifactModuleSync === "function") {
+    return loadBundledPluginPublicArtifactModuleSync(loadSingleParams);
+  }
+  if (typeof loadBundledPluginPublicArtifactModuleFromCandidatesSync === "function") {
+    return loadBundledPluginPublicArtifactModuleFromCandidatesSync(loadCandidateParams);
+  }
+  try {
+    return minifiedLoader(loadSingleParams);
+  } catch (error) {
+    if (
+      error instanceof TypeError &&
+      String(error.message).includes("artifactCandidates is not iterable")
+    ) {
+      return minifiedLoader(loadCandidateParams);
+    }
+    throw error;
+  }
+}
+
+if (!loadPublicArtifact()) {
+  throw new Error("Bundled OpenAI provider policy artifact did not load");
+}
 NODE
 
 require_js_alias_target() {


### PR DESCRIPTION
## Summary

Fix the package-content validator so it accepts both OpenClaw public-surface loader contracts:

- the pre-2026.6.11 single-artifact loader shape: `artifactBasename`
- the 2026.6.11 candidate-list loader shape: `artifactCandidates`

## Why

The scheduled `Pin Stable OpenClaw Version` workflow started failing while validating the 2026.6.11 pin. Both Linux and macOS supported-surface jobs failed in `openclaw-package-contents-2026.6.11` with:

```text
TypeError: params.artifactCandidates is not iterable
```

That came from the minified packaged loader resolving to the newer candidate-list helper while the check still called it with the older single-artifact parameter shape.

## Validation

Local checks available in this environment:

```bash
bash -n nix/scripts/check-package-contents.sh
git diff --check
node --check <embedded check-package-contents module>
```

Full Nix validation needs a Nix-enabled runner; this PR is intentionally small so GitHub Actions can prove the same supported-surface gate that failed in the scheduled workflow.
