### PR TITLE
fix(ci): preserve plugin versions on correction releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       ${{
         github.repository == 'openclaw/nix-openclaw' &&
         (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","github-actions[bot]"]'), github.actor)
+        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","vincentkoc","github-actions[bot]"]'), github.actor)
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -44,7 +44,7 @@ jobs:
       ${{
         github.repository == 'openclaw/nix-openclaw' &&
         (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","github-actions[bot]"]'), github.actor)
+        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","vincentkoc","github-actions[bot]"]'), github.actor)
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -81,7 +81,7 @@ jobs:
       ${{
         github.repository == 'openclaw/nix-openclaw' &&
         (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","github-actions[bot]"]'), github.actor)
+        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","vincentkoc","github-actions[bot]"]'), github.actor)
       }}
     runs-on: macos-14
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       ${{
         github.repository == 'openclaw/nix-openclaw' &&
         (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","vincentkoc","github-actions[bot]"]'), github.actor)
+        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","github-actions[bot]"]'), github.actor)
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -44,7 +44,7 @@ jobs:
       ${{
         github.repository == 'openclaw/nix-openclaw' &&
         (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","vincentkoc","github-actions[bot]"]'), github.actor)
+        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","github-actions[bot]"]'), github.actor)
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -81,7 +81,7 @@ jobs:
       ${{
         github.repository == 'openclaw/nix-openclaw' &&
         (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","vincentkoc","github-actions[bot]"]'), github.actor)
+        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","github-actions[bot]"]'), github.actor)
       }}
     runs-on: macos-14
     timeout-minutes: 60

--- a/.github/workflows/pin-stable-openclaw-version.yml
+++ b/.github/workflows/pin-stable-openclaw-version.yml
@@ -258,6 +258,7 @@ jobs:
       - validate-macos
     if: >-
       ${{
+        github.ref == 'refs/heads/main' &&
         needs.select.outputs.has_update == 'true' &&
         needs.validate-linux.outputs.validation_ok == 'true' &&
         needs.validate-macos.outputs.validation_ok == 'true'

--- a/.github/workflows/pin-stable-openclaw-version.yml
+++ b/.github/workflows/pin-stable-openclaw-version.yml
@@ -251,17 +251,50 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit 1
 
-  promote:
+  verify-materialization:
     needs:
       - select
       - validate-linux
       - validate-macos
     if: >-
       ${{
-        github.ref == 'refs/heads/main' &&
         needs.select.outputs.has_update == 'true' &&
         needs.validate-linux.outputs.validation_ok == 'true' &&
         needs.validate-macos.outputs.validation_ok == 'true'
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      materialization_digest: ${{ steps.verify.outputs.materialization_digest }}
+    steps:
+      - name: Verify cross-platform materialization
+        id: verify
+        env:
+          LINUX_MATERIALIZATION_DIGEST: ${{ needs.validate-linux.outputs.materialization_digest }}
+          MACOS_MATERIALIZATION_DIGEST: ${{ needs.validate-macos.outputs.materialization_digest }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$LINUX_MATERIALIZATION_DIGEST" || -z "$MACOS_MATERIALIZATION_DIGEST" ]]; then
+            echo "Missing validation materialization digest." >&2
+            exit 1
+          fi
+          if [[ "$LINUX_MATERIALIZATION_DIGEST" != "$MACOS_MATERIALIZATION_DIGEST" ]]; then
+            echo "Linux and macOS materialized different release diffs." >&2
+            echo "Linux: $LINUX_MATERIALIZATION_DIGEST" >&2
+            echo "macOS: $MACOS_MATERIALIZATION_DIGEST" >&2
+            exit 1
+          fi
+          echo "materialization_digest=$LINUX_MATERIALIZATION_DIGEST" >> "$GITHUB_OUTPUT"
+
+  promote:
+    needs:
+      - select
+      - verify-materialization
+    if: >-
+      ${{
+        github.ref == 'refs/heads/main' &&
+        needs.select.outputs.has_update == 'true'
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -280,23 +313,11 @@ jobs:
       - name: Promote selected release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LINUX_MATERIALIZATION_DIGEST: ${{ needs.validate-linux.outputs.materialization_digest }}
-          MACOS_MATERIALIZATION_DIGEST: ${{ needs.validate-macos.outputs.materialization_digest }}
+          VALIDATED_MATERIALIZATION_DIGEST: ${{ needs.verify-materialization.outputs.materialization_digest }}
         run: |
           set -euo pipefail
           git config user.name "openclaw-ci"
           git config user.email "ci@openclaw.local"
-
-          if [[ -z "$LINUX_MATERIALIZATION_DIGEST" || -z "$MACOS_MATERIALIZATION_DIGEST" ]]; then
-            echo "Missing validation materialization digest." >&2
-            exit 1
-          fi
-          if [[ "$LINUX_MATERIALIZATION_DIGEST" != "$MACOS_MATERIALIZATION_DIGEST" ]]; then
-            echo "Linux and macOS materialized different release diffs." >&2
-            echo "Linux: $LINUX_MATERIALIZATION_DIGEST" >&2
-            echo "macOS: $MACOS_MATERIALIZATION_DIGEST" >&2
-            exit 1
-          fi
 
           scripts/update-pins.sh apply \
             "${{ needs.select.outputs.source_tag }}" \
@@ -320,9 +341,9 @@ jobs:
               | shasum -a 256 \
               | awk '{ print $1 }'
           )"
-          if [[ "$promote_digest" != "$LINUX_MATERIALIZATION_DIGEST" ]]; then
+          if [[ "$promote_digest" != "$VALIDATED_MATERIALIZATION_DIGEST" ]]; then
             echo "Promote materialized a different release diff than validation." >&2
-            echo "Validated: $LINUX_MATERIALIZATION_DIGEST" >&2
+            echo "Validated: $VALIDATED_MATERIALIZATION_DIGEST" >&2
             echo "Promote:   $promote_digest" >&2
             exit 1
           fi

--- a/nix/checks/openclaw-runtime-plugin-locks.nix
+++ b/nix/checks/openclaw-runtime-plugin-locks.nix
@@ -5,6 +5,7 @@
 }:
 
 let
+  scriptsDir = ../scripts;
   generatedLocks = import ../generated/openclaw-runtime-plugins/default.nix;
   generatedLocksJson = builtins.toFile "openclaw-runtime-plugin-locks.json" (builtins.toJSON generatedLocks);
 in
@@ -25,7 +26,10 @@ stdenvNoCC.mkDerivation {
   };
 
   doCheck = true;
-  checkPhase = "${nodejs_22}/bin/node ${../scripts/check-openclaw-runtime-plugin-locks.mjs}";
+  checkPhase = ''
+    ${nodejs_22}/bin/node --test ${scriptsDir}/openclaw-runtime-plugin-version.test.mjs
+    ${nodejs_22}/bin/node ${scriptsDir}/check-openclaw-runtime-plugin-locks.mjs
+  '';
   installPhase = "${../scripts/empty-install.sh}";
 
   meta.description = "Validate generated OpenClaw runtime plugin locks and support report";

--- a/nix/generated/openclaw-runtime-plugins/report.json
+++ b/nix/generated/openclaw-runtime-plugins/report.json
@@ -1,5 +1,6 @@
 {
   "openclawVersion": "2026.7.1",
+  "runtimePluginVersion": "2026.7.1",
   "openclawReleaseTag": "v2026.7.1",
   "openclawRev": "2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4",
   "openclawHash": "sha256-37LZ10P+XGzfU3KVpRhfEElYscoUlE+zi85hmvicjLI=",

--- a/nix/lib/openclaw-gateway-common.nix
+++ b/nix/lib/openclaw-gateway-common.nix
@@ -41,6 +41,7 @@ let
     "pnpmMajor"
     "releaseTag"
     "releaseVersion"
+    "runtimePluginVersion"
     "applyPublicSurfaceHardlinksPatch"
     "applySkipPluginAutoEnableNixModePatch"
     "applyNixStorePluginOwnershipPatch"

--- a/nix/packages/openclaw-gateway-npm.nix
+++ b/nix/packages/openclaw-gateway-npm.nix
@@ -21,8 +21,8 @@ assert lib.assertMsg (lockedVersion == sourceInfo.releaseVersion)
   "OpenClaw npm lock version ${toString lockedVersion} does not match OpenClaw ${sourceInfo.releaseVersion}";
 assert lib.assertMsg ((bundledAcpx.openclawRuntimePlugin.id or null) == "acpx")
   "bundledAcpx must be the generated ACPX runtime plugin package";
-assert lib.assertMsg ((bundledAcpx.openclawRuntimePlugin.version or null) == sourceInfo.releaseVersion)
-  "ACPX runtime plugin version ${toString (bundledAcpx.openclawRuntimePlugin.version or null)} does not match OpenClaw ${sourceInfo.releaseVersion}";
+assert lib.assertMsg ((bundledAcpx.openclawRuntimePlugin.version or null) == sourceInfo.runtimePluginVersion)
+  "ACPX runtime plugin version ${toString (bundledAcpx.openclawRuntimePlugin.version or null)} does not match OpenClaw runtime plugins ${sourceInfo.runtimePluginVersion}";
 
 buildNpmPackageForOpenClaw {
   pname = "openclaw-gateway";

--- a/nix/scripts/check-openclaw-runtime-plugin-locks.mjs
+++ b/nix/scripts/check-openclaw-runtime-plugin-locks.mjs
@@ -132,6 +132,7 @@ const lockFiles = fs
 
 assert(report.openclawVersion && !/[~^*]|latest|beta$/.test(report.openclawVersion), "report has invalid OpenClaw version");
 assert(report.openclawVersion === sourceInfo.releaseVersion, "report OpenClaw version is stale relative to openclaw-source.nix");
+assert(report.runtimePluginVersion === sourceInfo.runtimePluginVersion, "report runtime plugin version is stale relative to openclaw-source.nix");
 assert(report.openclawReleaseTag === sourceInfo.releaseTag, "report OpenClaw release tag is stale relative to openclaw-source.nix");
 assert(report.openclawRev === sourceInfo.rev, "report OpenClaw rev is stale relative to openclaw-source.nix");
 assert(report.openclawHash === sourceInfo.hash, "report OpenClaw hash is stale relative to openclaw-source.nix");
@@ -195,3 +196,10 @@ for (const row of skipped) {
 for (const expected of ["slack", "discord", "brave", "diagnostics-prometheus"]) {
   assert(findById(supported, expected), `previously supported id ${expected} disappeared`);
 }
+
+const acpx = findById(supported, "acpx");
+assert(acpx, "previously supported id acpx disappeared");
+assert(
+  acpx.version === report.runtimePluginVersion,
+  `ACPX version ${acpx.version} does not match runtime plugin version ${report.runtimePluginVersion}`,
+);

--- a/nix/scripts/openclaw-runtime-plugin-version.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-version.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export function correctionBaseVersion(releaseVersion) {
+  return releaseVersion.match(/^(\d+\.\d+\.\d+)-[1-9]\d*$/)?.[1] ?? null;
+}
+
+export function resolveRuntimePluginVersion(releaseVersion, packageVersion) {
+  const allowedVersions = [releaseVersion, correctionBaseVersion(releaseVersion)].filter(Boolean);
+  if (!allowedVersions.includes(packageVersion)) {
+    throw new Error(
+      `OpenClaw package version ${packageVersion} must match release ${releaseVersion}`
+      + ` or its correction base version`,
+    );
+  }
+  return packageVersion;
+}
+
+export function defaultCatalogVersion(catalogSource, releaseVersion, runtimePluginVersion) {
+  return catalogSource === "official" ? runtimePluginVersion : releaseVersion;
+}
+
+function main(args) {
+  if (args.length !== 2) {
+    throw new Error(
+      "usage: openclaw-runtime-plugin-version.mjs <release-version> <source-package.json>",
+    );
+  }
+  const [releaseVersion, packageJsonPath] = args;
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  if (typeof packageJson.version !== "string" || !packageJson.version) {
+    throw new Error(`${packageJsonPath} has no package version`);
+  }
+  console.log(resolveRuntimePluginVersion(releaseVersion, packageJson.version));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2));
+}

--- a/nix/scripts/openclaw-runtime-plugin-version.test.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-version.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  correctionBaseVersion,
+  defaultCatalogVersion,
+  resolveRuntimePluginVersion,
+} from "./openclaw-runtime-plugin-version.mjs";
+
+test("normal releases use the release version for official plugins", () => {
+  assert.equal(correctionBaseVersion("2026.7.1"), null);
+  assert.equal(resolveRuntimePluginVersion("2026.7.1", "2026.7.1"), "2026.7.1");
+  assert.equal(defaultCatalogVersion("official", "2026.7.1", "2026.7.1"), "2026.7.1");
+});
+
+test("correction releases use tagged package metadata for official plugins", () => {
+  assert.equal(correctionBaseVersion("2026.7.1-2"), "2026.7.1");
+  assert.equal(resolveRuntimePluginVersion("2026.7.1-2", "2026.7.1"), "2026.7.1");
+  assert.equal(
+    defaultCatalogVersion("official", "2026.7.1-2", "2026.7.1"),
+    "2026.7.1",
+  );
+  assert.equal(
+    defaultCatalogVersion("community", "2026.7.1-2", "2026.7.1"),
+    "2026.7.1-2",
+  );
+});
+
+test("runtime plugin metadata cannot drift from the release line", () => {
+  assert.throws(
+    () => resolveRuntimePluginVersion("2026.7.1-2", "2026.7.2"),
+    /must match release 2026\.7\.1-2 or its correction base version/,
+  );
+  assert.throws(
+    () => resolveRuntimePluginVersion("2026.7.1-beta.2", "2026.7.1"),
+    /must match release 2026\.7\.1-beta\.2 or its correction base version/,
+  );
+});

--- a/nix/scripts/update-openclaw-runtime-plugin-locks.mjs
+++ b/nix/scripts/update-openclaw-runtime-plugin-locks.mjs
@@ -7,6 +7,11 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  defaultCatalogVersion,
+  resolveRuntimePluginVersion,
+} from "./openclaw-runtime-plugin-version.mjs";
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../..");
 const sourceInfoPath = path.join(repoRoot, "nix/sources/openclaw-source.nix");
@@ -166,6 +171,7 @@ function resolveOpenClawSourcePath() {
     "pnpmMajor",
     "releaseTag",
     "releaseVersion",
+    "runtimePluginVersion",
     "applyPublicSurfaceHardlinksPatch",
     "applySkipPluginAutoEnableNixModePatch",
     "applyNixStorePluginOwnershipPatch",
@@ -1237,7 +1243,7 @@ async function buildArtifactLock(row, artifact) {
   }
 }
 
-async function processRow(row, releaseVersion) {
+async function processRow(row, releaseVersion, runtimePluginVersion) {
   if (!row.id) {
     return { skipped: skip(row, "missing-plugin-id", "catalog row has no plugin, channel, or provider id") };
   }
@@ -1253,7 +1259,11 @@ async function processRow(row, releaseVersion) {
       return { skipped: skip(row, "invalid-clawhub-spec", row.install.clawhubSpec ?? "") };
     }
     if (!clawhubPackage.version) {
-      clawhubPackage.version = releaseVersion;
+      clawhubPackage.version = defaultCatalogVersion(
+        row.source,
+        releaseVersion,
+        runtimePluginVersion,
+      );
     }
     if (!isExactVersion(clawhubPackage.version)) {
       return {
@@ -1273,7 +1283,11 @@ async function processRow(row, releaseVersion) {
   }
 
   if (!npmPackage.version) {
-    npmPackage.version = releaseVersion;
+    npmPackage.version = defaultCatalogVersion(
+      row.source,
+      releaseVersion,
+      runtimePluginVersion,
+    );
   }
 
   if (!isExactVersion(npmPackage.version)) {
@@ -1287,10 +1301,24 @@ async function processRow(row, releaseVersion) {
 }
 
 const releaseVersion = readSourceField("releaseVersion");
+const runtimePluginVersion = readSourceField("runtimePluginVersion");
 const releaseTag = readSourceField("releaseTag");
 const pinnedRev = readSourceField("rev");
 const pinnedHash = readSourceField("hash");
 const openclawSourcePath = resolveOpenClawSourcePath();
+const taggedPackageVersion = JSON.parse(
+  fs.readFileSync(path.join(openclawSourcePath, "package.json"), "utf8"),
+).version;
+const expectedRuntimePluginVersion = resolveRuntimePluginVersion(
+  releaseVersion,
+  taggedPackageVersion,
+);
+if (runtimePluginVersion !== expectedRuntimePluginVersion) {
+  throw new Error(
+    `runtimePluginVersion ${runtimePluginVersion} does not match tagged package metadata`
+    + ` ${expectedRuntimePluginVersion}`,
+  );
+}
 const rows = readCatalogRows(openclawSourcePath);
 const locks = [];
 const supported = [];
@@ -1305,7 +1333,7 @@ for (const row of rows) {
   }
   seenCatalogKeys.add(dedupeKey);
 
-  const result = await processRow(row, releaseVersion);
+  const result = await processRow(row, releaseVersion, runtimePluginVersion);
   if (result.lock) {
     locks.push(result.lock);
     supported.push(result.supported);
@@ -1328,6 +1356,7 @@ fs.mkdirSync(outputDir, { recursive: true });
 
 const report = {
   openclawVersion: releaseVersion,
+  runtimePluginVersion,
   openclawReleaseTag: releaseTag,
   openclawRev: pinnedRev,
   openclawHash: pinnedHash,

--- a/nix/sources/openclaw-source.nix
+++ b/nix/sources/openclaw-source.nix
@@ -8,6 +8,7 @@
   applyNixStorePluginOwnershipPatch = true;
   releaseTag = "v2026.7.1";
   releaseVersion = "2026.7.1";
+  runtimePluginVersion = "2026.7.1";
   rev = "2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4";
   hash = "sha256-37LZ10P+XGzfU3KVpRhfEElYscoUlE+zi85hmvicjLI=";
   gatewayNpmDepsHash = "sha256-+/Ty+5xwfg1/C5WmLkwztHZZr6KhkMaBm5I/wkE9cP0=";

--- a/scripts/update-pins.sh
+++ b/scripts/update-pins.sh
@@ -13,6 +13,7 @@ config_options_file="$repo_root/nix/generated/openclaw-config-options.nix"
 gateway_npm_wrapper_dir="$repo_root/nix/npm/openclaw"
 runtime_plugin_lock_rel_dir="nix/generated/openclaw-runtime-plugins"
 runtime_plugin_lock_dir="$repo_root/$runtime_plugin_lock_rel_dir"
+runtime_plugin_version_resolver="$repo_root/nix/scripts/openclaw-runtime-plugin-version.mjs"
 npm_fake_hash="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 apply_backup_dir=""
 apply_success=0
@@ -216,6 +217,12 @@ source_pnpm_major() {
   esac
 }
 
+source_runtime_plugin_version() {
+  local source_path="$1"
+  local release_version="$2"
+  node "$runtime_plugin_version_resolver" "$release_version" "$source_path/package.json"
+}
+
 pnpm_shell_package() {
   local major="$1"
   case "$major" in
@@ -373,7 +380,7 @@ apply_release() {
   local selected_sha="$2"
   local app_tag="$3"
   local app_url="$4"
-  local source_version source_url source_prefetch source_hash source_store_path selected_pnpm_major public_surface_hardlinks_patch apply_skip_plugin_auto_enable_patch app_version app_hash
+  local source_version source_url source_prefetch source_hash source_store_path selected_pnpm_major runtime_plugin_version public_surface_hardlinks_patch apply_skip_plugin_auto_enable_patch app_version app_hash
 
   source_version="${source_tag#v}"
   source_url="https://github.com/openclaw/openclaw/archive/${selected_sha}.tar.gz"
@@ -386,6 +393,7 @@ apply_release() {
     exit 1
   fi
   selected_pnpm_major=$(source_pnpm_major "$source_store_path")
+  runtime_plugin_version=$(source_runtime_plugin_version "$source_store_path" "$source_version")
   public_surface_hardlinks_patch=$(source_public_surface_hardlinks_patch "$source_store_path")
   apply_skip_plugin_auto_enable_patch=$(source_needs_skip_plugin_auto_enable_nix_mode_patch "$source_store_path")
 
@@ -430,8 +438,8 @@ apply_release() {
   }
   trap cleanup_apply EXIT
 
-  perl -0pi -e 's|  releaseTag = "[^"]+";\n||g; s|  releaseVersion = "[^"]+";\n||g;' "$source_file"
-  perl -0pi -e "s|rev = \"[^\"]+\";|releaseTag = \"${source_tag}\";\n  releaseVersion = \"${source_version}\";\n  rev = \"${selected_sha}\";|" "$source_file"
+  perl -0pi -e 's|  releaseTag = "[^"]+";\n||g; s|  releaseVersion = "[^"]+";\n||g; s|  runtimePluginVersion = "[^"]+";\n||g;' "$source_file"
+  perl -0pi -e "s|rev = \"[^\"]+\";|releaseTag = \"${source_tag}\";\n  releaseVersion = \"${source_version}\";\n  runtimePluginVersion = \"${runtime_plugin_version}\";\n  rev = \"${selected_sha}\";|" "$source_file"
   if grep -q 'pnpmMajor = ' "$source_file"; then
     perl -0pi -e "s|pnpmMajor = \"[^\"]+\";|pnpmMajor = \"${selected_pnpm_major}\";|" "$source_file"
   else
@@ -469,7 +477,7 @@ case "$mode" in
     ;;
   apply)
     [[ $# -eq 5 ]] || { usage; exit 1; }
-    require_cmds jq nix perl unzip find
+    require_cmds jq nix node perl unzip find
     apply_release "$2" "$3" "$4" "$5"
     ;;
   *) usage; exit 1 ;;


### PR DESCRIPTION
## Summary

- separate the upstream correction release version from the tagged runtime-plugin package cohort
- derive `runtimePluginVersion` from the tagged source `package.json`
- use that version for official catalog defaults and ACPX assertions while keeping the gateway on the correction release
- validate the version relation and generated report in the Nix-owned runtime-plugin lock gate
- restrict stable-pin promotion to `main` so branch dispatches are validation-only
- require Linux/macOS materialization digest equality in a read-only job before promotion
- preserve the existing native-CI trusted-actor boundary unchanged

## Root cause

The stable pin updater used one `releaseVersion` for two different artifacts. For `v2026.7.1-2`, the gateway release is `2026.7.1-2`, but the tagged source package and official runtime plugins remain `2026.7.1`. Feeding the correction suffix into official plugin specs made the generator reject the catalog and then fail when the ACPX lock was absent.

`releaseVersion` remains owned by the gateway pin. `runtimePluginVersion` is now owned by tagged package metadata and is accepted only when it exactly matches the release or the numeric correction base.

The stable-pin workflow also allowed a manual non-main dispatch to reach the write-scoped promotion job. Promotion now requires `refs/heads/main`, preserving scheduled and manual main promotion while making branch dispatches validation-only.

Cross-platform digest equality previously lived inside the promotion job, so validation-only branch dispatches could not enforce it. A read-only zero-permission verification job now owns the equality check and passes one verified digest to main-only promotion.

## Evidence

- `node --test nix/scripts/openclaw-runtime-plugin-version.test.mjs` (3/3)
- `bash -n scripts/update-pins.sh`
- Node syntax checks for the resolver and lock updater
- workflow YAML parse
- `git diff --check`
- `.github/workflows/ci.yml` is byte-identical to `main`
- transient correction materialization reached the runtime-plugin generator: `69 supported, 8 skipped`; ACPX resolved as `@openclaw/acpx@2026.7.1`
- exact-head validation-only run passed: https://github.com/openclaw/nix-openclaw/actions/runs/30912428524
  - `select`: success; selected `v2026.7.1-2`
  - `validate-linux`: success
  - `validate-macos`: success
  - `verify-materialization`: success
  - `promote`: skipped
  - `main`: unchanged at `393177115c64d5066f174967cb94eb10aadd6a3e`

## Merge gate

Passed on exact head `e4a541ae3ead42252bf5c919172db44d55575a84`: `v2026.7.1-2` selected; Linux, macOS, and `verify-materialization` succeeded; promotion skipped; `main` remained unchanged.
