### PR TITLE
docs: clarify Gmail hook session keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ programs.openclaw.bundledPlugins = {
   poltergeist.enable = false; # File watching and automation
   sag.enable = false;        # Text-to-speech
   camsnap.enable = false;    # Camera snapshots
-  gogcli.enable = false;     # Google Calendar
+  gogcli.enable = false;     # Google Workspace CLI
   goplaces.enable = true;    # Google Places API
   sonoscli.enable = false;   # Sonos control
   imsg.enable = false;       # iMessage
@@ -517,10 +517,38 @@ programs.openclaw.bundledPlugins.goplaces = {
 | `poltergeist` | File watching and automation |
 | `sag` | Text-to-speech |
 | `camsnap` | Take photos from connected cameras |
-| `gogcli` | Google Calendar integration |
+| `gogcli` | Google Workspace CLI |
 | `goplaces` | Google Places API (New) CLI |
 | `sonoscli` | Control Sonos speakers |
 | `imsg` | Send/read iMessages |
+
+#### Gmail hooks with gogcli
+
+Enabling `bundledPlugins.gogcli` installs `gog` and its OpenClaw skill. It does
+not run `openclaw hooks gmail setup` or mutate the Nix-owned `openclaw.json`.
+Declare the upstream Gmail hook configuration under
+`programs.openclaw.config.hooks` instead.
+
+The Gmail preset uses a templated `hook:gmail:` session key. OpenClaw rejects
+that callback with HTTP 400 unless request session keys are enabled and bounded
+to the expected prefix:
+
+```nix
+programs.openclaw.config.hooks = {
+  enabled = true;
+  presets = [ "gmail" ];
+  defaultSessionKey = "hook:gmail:default";
+  allowRequestSessionKey = true;
+  allowedSessionKeyPrefixes = [ "hook:gmail:" ];
+
+  # Add the upstream gmail block here.
+};
+```
+
+Keep the prefix narrow: this option lets the authenticated hook caller select
+the target session. Follow the upstream
+[Gmail Pub/Sub setup](https://docs.openclaw.ai/automation/cron-jobs#gmail-pubsub-integration)
+for Google credentials, hook tokens, and public-ingress security.
 
 ### Adding custom nix-openclaw plugins
 


### PR DESCRIPTION
## Summary

- clarify that the bundled gogcli plugin installs the tool and skill but does not mutate Nix-owned OpenClaw config
- document the Gmail hook session-key settings needed to avoid HTTP 400 callbacks
- keep the caller-controlled session key restricted to the Gmail prefix and link upstream ingress guidance

Addresses #97.

## Proof

- `git diff --check`
- OpenClaw 2026.7.1-2 local gateway: an authenticated hook request using `hook:gmail:test-message` returned HTTP 400 without `hooks.allowRequestSessionKey`, then HTTP 200 after enabling it with `defaultSessionKey = "hook:gmail:default"` and `allowedSessionKeyPrefixes = [ "hook:gmail:" ]`
- outside-prefix anti-cheat request using `hook:other:test-message` remained HTTP 400
- structured autoreview: clean, no accepted/actionable findings

Local Nix evaluation was unavailable because this worker host does not have Nix installed; current main's generated options already contain every documented field.
