### PR TITLE
fix(security): complete string sanitization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
 
+      - name: Test JavaScript contracts
+        run: nix shell nixpkgs#nodejs_22 --command node --test maintainers/scripts/markdown-table.test.mjs
+
       - name: Build Linux supported surface
         run: |
           timeout --foreground 50m maintainers/scripts/ci-nix-build.sh linux-supported-surface \

--- a/maintainers/scripts/markdown-table.mjs
+++ b/maintainers/scripts/markdown-table.mjs
@@ -1,0 +1,6 @@
+export function markdownTableCell(value) {
+  return String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/\r\n?|\n/g, " ");
+}

--- a/maintainers/scripts/markdown-table.test.mjs
+++ b/maintainers/scripts/markdown-table.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { markdownTableCell } from "./markdown-table.mjs";
+
+test("escapes every backslash and table separator", () => {
+  assert.equal(markdownTableCell(String.raw`left\|middle\\|right`), String.raw`left\\\|middle\\\\\|right`);
+});
+
+test("keeps untrusted values inside one table row", () => {
+  assert.equal(markdownTableCell("first\r\nsecond\nthird\rfourth"), "first second third fourth");
+});
+
+test("normalizes non-string values", () => {
+  assert.equal(markdownTableCell(42), "42");
+});

--- a/maintainers/scripts/summarize-nix-build-closure.mjs
+++ b/maintainers/scripts/summarize-nix-build-closure.mjs
@@ -2,6 +2,8 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 
+import { markdownTableCell as markdownCell } from "./markdown-table.mjs";
+
 function usage() {
   process.stderr.write(`Usage:
   maintainers/scripts/summarize-nix-build-closure.mjs [--label <label>] [--limit <count>] [--summary-file <path>] <outputs-file>
@@ -197,10 +199,6 @@ function top(entries, field, limit) {
   return [...entries]
     .sort((left, right) => right[field] - left[field] || left.name.localeCompare(right.name))
     .slice(0, limit);
-}
-
-function markdownCell(value) {
-  return value.replace(/\|/g, "\\|");
 }
 
 function formatBytes(bytes) {

--- a/maintainers/scripts/summarize-nix-build-log.mjs
+++ b/maintainers/scripts/summarize-nix-build-log.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 
+import { markdownTableCell as markdownCell } from "./markdown-table.mjs";
+
 function usage() {
   process.stderr.write(`Usage:
   maintainers/scripts/summarize-nix-build-log.mjs [--label <label>] [--seconds <seconds>] [--summary-file <path>] <log>
@@ -293,10 +295,6 @@ function render(groups, title) {
   }
 
   return `${lines.join("\n")}\n`;
-}
-
-function markdownCell(value) {
-  return value.replace(/\|/g, "\\|");
 }
 
 function formatSeconds(seconds) {

--- a/maintainers/scripts/summarize-nixos-test-log.mjs
+++ b/maintainers/scripts/summarize-nixos-test-log.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 
+import { markdownTableCell as markdownCell } from "./markdown-table.mjs";
+
 function usage() {
   process.stderr.write(`Usage:
   maintainers/scripts/summarize-nixos-test-log.mjs [--label <label>] [--limit <count>] [--summary-file <path>] <log>
@@ -174,10 +176,6 @@ function render({ label, limit, finished, gatewayEvents, startupTrace }) {
   }
 
   return `${lines.join("\n")}\n`;
-}
-
-function markdownCell(value) {
-  return String(value).replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
 }
 
 function formatSeconds(value) {

--- a/nix/scripts/openclaw-runtime-plugin-fetch-source.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-fetch-source.mjs
@@ -49,7 +49,7 @@ function parseNpmSpec(spec) {
 }
 
 function npmRegistryUrl(packageName) {
-  return `https://registry.npmjs.org/${encodeURIComponent(packageName).replace("%2F", "%2f")}`;
+  return `https://registry.npmjs.org/${encodeURIComponent(packageName)}`;
 }
 
 function clawHubArtifactUrl(packageName, version) {

--- a/nix/scripts/update-openclaw-runtime-plugin-locks.mjs
+++ b/nix/scripts/update-openclaw-runtime-plugin-locks.mjs
@@ -198,7 +198,7 @@ function resolveOpenClawSourcePath() {
 }
 
 function npmRegistryUrl(packageName) {
-  return `https://registry.npmjs.org/${encodeURIComponent(packageName).replace("%2F", "%2f")}`;
+  return `https://registry.npmjs.org/${encodeURIComponent(packageName)}`;
 }
 
 function pickDefined(object) {


### PR DESCRIPTION
## Summary

- remove unnecessary post-processing from canonical `encodeURIComponent` npm package paths
- centralize Markdown table-cell escaping so backslashes, separators, and line breaks are handled in the correct order
- run adversarial table-cell regression coverage in the hosted Linux gate

## Root cause

Two independent sanitization invariants were incomplete:

1. The npm registry helpers rewrote only the first encoded slash even though the registry accepts the canonical `%2F` output directly.
2. Three CI summarizers escaped table separators without first escaping backslashes, allowing crafted input to alter the intended Markdown escaping.

This fixes CodeQL alerts:

- https://github.com/openclaw/nix-openclaw/security/code-scanning/1
- https://github.com/openclaw/nix-openclaw/security/code-scanning/2
- https://github.com/openclaw/nix-openclaw/security/code-scanning/3
- https://github.com/openclaw/nix-openclaw/security/code-scanning/4
- https://github.com/openclaw/nix-openclaw/security/code-scanning/5

## Validation

- `node --test maintainers/scripts/markdown-table.test.mjs`
- `node --check` on all five affected scripts plus the shared helper
- hostile table-label/log fixture preserves one Markdown row and escapes every slash/pipe
- live npm registry source fetch for `@openclaw/slack@2026.7.1` produced a valid 3,860,207-byte tarball
- workflow YAML parse
- `git diff --check`

Production/CI: +17/-14 (net +3). Tests: +16/-0.
